### PR TITLE
Add .gitignore with API key file and log dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+BasicBotAPIKey.txt
+log


### PR DESCRIPTION
Paths listed in a .gitignore file will be ignored by git (so for example if you do **git add .** it will skip anything in the .gitignore).

Putting config files especially those that contain API keys in the .gitignore helps prevent them from being accidentally committed and pushed (and then found by the trolls who scan github for bot tokens and use them to destroy your server).

Other paths that should be ignored by git can also be added to .gitignore.