### PR TITLE
Rai will try to open the DM channel before sending a direct message

### DIFF
--- a/cogs/channel_mods.py
+++ b/cogs/channel_mods.py
@@ -1126,7 +1126,7 @@ class ChannelMods(commands.Cog):
             emb.add_field(name="Reason", value=reason)
         if not silent:
             try:
-                await target.send(embed=emb)
+                await hf.safe_send(target, embed=emb)
             except discord.Forbidden:
                 await hf.safe_send(ctx, "This user has DMs disabled so I couldn't send the notification. I'll "
                                         "keep them muted but they won't receive the notification for it.")

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -2441,7 +2441,7 @@ class General(commands.Cog):
             emb.add_field(name="Reason", value=reason)
         if not silent:
             try:
-                await target.send(embed=emb)
+                await hf.safe_send(target, embed=emb)
             except discord.Forbidden:
                 await hf.safe_send(ctx, "This user has DMs disabled so I couldn't send the notification.  I'll "
                                         "keep them muted but they will not receive the reason for it.")

--- a/cogs/submod.py
+++ b/cogs/submod.py
@@ -255,7 +255,7 @@ class Submod(commands.Cog):
 
             if 'send' in content:
                 try:
-                    await target.send(embed=em)
+                    await hf.safe_send(target, embed=em)
                 except discord.Forbidden:
                     await hf.safe_send(ctx, f"{target.mention} has PMs disabled so I didn't send the notification.")
 

--- a/cogs/utils/helper_functions.py
+++ b/cogs/utils/helper_functions.py
@@ -147,6 +147,9 @@ async def safe_send(destination, content=None, *, wait=False, embed=None, delete
             return
 
     try:
+        if isinstance(destination, discord.Member):
+            if not destination.dm_channel:
+                await destination.create_dm()
         return await destination.send(content, embed=embed, delete_after=delete_after, file=file)
     except discord.Forbidden:
         if isinstance(destination, commands.Context):

--- a/cogs/utils/helper_functions.py
+++ b/cogs/utils/helper_functions.py
@@ -148,7 +148,7 @@ async def safe_send(destination, content=None, *, wait=False, embed=None, delete
 
     try:
         if isinstance(destination, discord.Member):
-            if not destination.dm_channel:
+            if not destination.DMChannel:
                 await destination.create_dm()
         return await destination.send(content, embed=embed, delete_after=delete_after, file=file)
     except discord.Forbidden:


### PR DESCRIPTION
- safe_send updated so Rai tries to open a Direct Message channel with the target member before sending a direct message.
- safe_send added to warn, mute, voicemute and ban commands.