### PR TITLE
Damer dictionary lookup

### DIFF
--- a/Rai.py
+++ b/Rai.py
@@ -130,7 +130,7 @@ class Rai(Bot):
         initial_extensions = ['cogs.main', 'cogs.admin', 'cogs.channel_mods', 'cogs.general', 'cogs.logger',
                               'cogs.math', 'cogs.owner', 'cogs.questions', 'cogs.reports', 'cogs.stats', 'cogs.submod',
                               'cogs.events', 'cogs.interactions', 'cogs.clubs', 'cogs.jpserv', 'cogs.message',
-                              'cogs.dictionary', 'cogs.heartbeat', 'cogs.dropdown', 'cogs.cnserver']
+                              'cogs.dictionary', 'cogs.damer', 'cogs.heartbeat', 'cogs.dropdown', 'cogs.cnserver']
 
         # cogs.background is loaded in main.py
         for extension in initial_extensions:

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ kiwisolver>=1.4.4
 langdetect-py
 Levenshtein
 lingua-language-detector
+lxml
 matplotlib
 multidict
 nltk


### PR DESCRIPTION
Add initial commands `damer` and `damerexp` to look up words in the [Diccionario de americanismos](https://www.asale.org/damer/). 

The `damer` command will return word definitions with an option to switch to expressions containing the word, if available. If no definitions are available, but there are expressions, the command will default to showing the expressions.

The `damerexp` command will return expressions for the requested word with an option to switch to the word definitions, if available.

Tested using the following commands:
```
r;damer ñurdo
r;damer test
r;damer pasar
r;damer asopado
r;damer asd
r;damer asdasd
r;damer hacer

r;damerexp ñurdo
r;damerexp test
r;damerexp pasar
r;damerexp asopado
r;damerexp asd
r;damerexp asdasd
r;damerexp hacer
```