### PR TITLE
Damer etymology and embed fixes

### DIFF
--- a/tests/cogs/damer_sample_htmls/asopado.html
+++ b/tests/cogs/damer_sample_htmls/asopado.html
@@ -1,0 +1,1362 @@
+<!DOCTYPE html>
+<html lang="es">
+<head><noscript><style>form.antibot * :not(.antibot-message) { display: none !important; }</style></noscript>
+<link rel="preload" href="/sites/default/files/css/css_2toHNXfbnPicu5GM0gX9NZ5orfKOc_JkPXeCbZqaWws.css" as="style">
+<link rel="preload" href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&amp;display=swap" as="style">
+<link rel="preload" href="https://fonts.googleapis.com/css2?family=Merriweather:wght@700&amp;display=swap" as="style">
+<link rel="preload" href="/sites/default/files/css/css_MKU0IOMhjZnRGgSeMxmlSpwNVcEMZOFPTb3EZkC-BVI.css" as="style">
+<link rel="preload" href="/sites/default/files/js/js_7hSOT9HVKxMvGlrclR4TDcqOUtAR-0e88Vkq_P_PROE.js" as="script">
+<link rel="preload" href="/damer/css/20201019.css" as="style">
+<link rel="preload" href="/damer/js/20210406.js" as="script">
+<link rel="preload" href="/themes/custom/front/assets/fonts/lato/lato-bold-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/lato/lato-regular-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/merriweather/merriweather-black-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/merriweather/merriweather-light-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/merriweather/merriweather-regular-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="canonical" href="https://www.asale.org/damer/asopado"/>
+<title>asopado, asopada | Diccionario de americanismos | ASALE</title>
+<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="I. 1. Pa. Plato de arroz cocido con carne o pollo y algunas verduras, con la apariencia de una sopa espesa. I. 1. Ch. Referido a persona , escasa de entendimiento y lenta . pop + cult → espon ^ desp."/>
+<meta name="keywords" content="asopado, definición de asopado, significado de asopado, ASALE, RAE"/>
+<meta name="author" content="ASALE"/>
+<meta name="robots" content="index,follow"/>
+<meta name="rating" content="safe for kids"/>
+<meta name="rights" content="Asociación de Academias de la Lengua Española © Todos los derechos reservados"/>
+<meta name="author" content="ASALE">
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:site" content="\@ASALEinforma"/>
+<meta name="twitter:url" content="https://www.asale.org/damer/asopado"/>
+<meta name="twitter:title" content="asopado, asopada | Diccionario de americanismos"/>
+<meta name="twitter:description" content="I. 1. Pa. Plato de arroz cocido con carne o pollo y algunas verduras, con la apariencia de una sopa espesa. I. 1. Ch. Referido a persona , escasa de entendimiento y lenta . pop + cult → espon ^ desp."/>
+<meta name="twitter:image" content="/damer/img/logo-asale.png"/>
+<meta name="twitter:image:alt" content="«Diccionario de americanismos»"/>
+<meta property="article:author" content="https://es-es.facebook.com/asale"/>
+<meta property="og:title" content="asopado, asopada | Diccionario de americanismos"/>
+<meta property="og:type" content="website"/>
+<meta property="og:site_name" content="«Diccionario de americanismos»"/>
+<meta property="og:url" content="https://www.asale.org/damer/asopado"/>
+<meta property="og:description" content="I. 1. Pa. Plato de arroz cocido con carne o pollo y algunas verduras, con la apariencia de una sopa espesa. I. 1. Ch. Referido a persona , escasa de entendimiento y lenta . pop + cult → espon ^ desp."/>
+<meta property="og:locale" content="es"/>
+<meta property="og:image" content="/damer/img/logo-asale.png"/>
+<meta property="og:image:type" content="image/png"/>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<link rel="shortcut icon" href="/themes/custom/front/favicon.ico" />
+<link rel="mask-icon" href="/themes/custom/front/src/assets/images/favicons/safari-pinned-tab.svg" />
+<link rel="icon" sizes="16x16" href="/themes/custom/front/src/assets/images/favicons/favicon-16x16.png" />
+<link rel="icon" sizes="32x32" href="/themes/custom/front/src/assets/images/favicons/favicon-32x32.png" />
+<link rel="apple-touch-icon" sizes="180x180" href="/themes/custom/front/src/assets/images/favicons/apple-touch-icon.png" />
+<link rel="apple-touch-icon-precomposed" sizes="180x180" href="/themes/custom/front/src/assets/images/favicons/apple-touch-icon.png" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=2, minimum-scale=1, user-scalable=yes" />
+<!--[if lt IE 9]><script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+<script type="application/ld+json">
+[{"@context": "http://schema.org/"},{"@type": ["DefinedTermSet","Book"],"@id": "https://www.asale.org/damer","name": "Diccionario de americanismos RAE - ASALE","image": "https://www.asale.org/damer/img/logo-asale.png","description": "Versión electrónica del «Diccionario de americanismos»."},{"@type": "DefinedTerm","@id": "https://www.asale.org/damer/asopado","name": "asopado","description": "I. 1. Pa. Plato de arroz cocido con carne o pollo y algunas verduras, con la apariencia de una sopa espesa. I. 1. Ch. Referido a persona , escasa de entendimiento y lenta . pop + cult → espon ^ desp.","inDefinedTermSet": "https://www.asale.org/damer"}]
+</script><link rel="stylesheet" media="all" href="/sites/default/files/css/css_2toHNXfbnPicu5GM0gX9NZ5orfKOc_JkPXeCbZqaWws.css"/>
+<link rel="stylesheet" media="all" href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&amp;display=swap"/>
+<link rel="stylesheet" media="all" href="https://fonts.googleapis.com/css2?family=Merriweather:wght@700&amp;display=swap"/>
+<link rel="stylesheet" media="all" href="/sites/default/files/css/css_MKU0IOMhjZnRGgSeMxmlSpwNVcEMZOFPTb3EZkC-BVI.css"/>
+<script>window.a2a_config=window.a2a_config||{};a2a_config.callbacks=[];a2a_config.overlays=[];a2a_config.templates={};a2a_config.static_server= "http://www.asale.org/sites/default/files/addtoany/menu/oafg07ee";a2a_config.icon_color = "transparent,#000";</script>
+
+<link rel="stylesheet" media="all" href="/damer/css/20201019.css"/>
+</head>
+<body class="path--node body-sidebars-none alias--noticia-primera-reunion-plenaria-virtual-de-directores-y-presidentes-de-las-academias-de-la-lengua nodetype--noticia logged-out" data-aos-easing="ease" data-aos-duration="400" data-aos-delay="0">
+<div role="main">
+<div class="dialog-off-canvas-main-canvas" data-off-canvas-main-canvas="">
+<div class="page-standard" id="pg__c">
+
+<header id="header" class="header">
+
+  <div class="header__logo">
+    <div class="img">
+                <a href="/" title="Inicio - ASALE" rel="home" class="site-logo">
+            <img src="/themes/custom/asale/assets/images/logo-asale.png" alt="Logo ASALE"/>
+          </a>
+          </div>
+  </div>
+
+  <div class="header-menu-search">
+
+    <nav class="header-menu">
+
+      <div class="main-menu-container">
+        <span class="menu-buttom__close">
+  <svg class="icon icon--xsmall icon-black">
+    <title>cerrar</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#close"></use>
+  </svg>
+</span>
+        
+
+<nav role="navigation" aria-labelledby="block-navegacionprincipalasale" id="block-navegacionprincipalasale" class="block block-menu navigation block-system-menublock menu--main-asale">
+      
+        
+
+
+              <ul class="menu-list main">
+              <li class="menu-list__item" >
+
+                  <div class="parent-item">
+            <a href="/la-asociacion" data-drupal-link-system-path="node/29051">La Asociación</a>
+            <span class="menu-collapse">
+              <svg class="icon icon--xsmall icon-black">
+                <title>Abrir submenu</title>
+                <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-bottom"></use>
+              </svg>
+            </span>
+          </div>
+        
+
+                                <ul>
+              <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/bienvenida" data-drupal-link-system-path="node/31480">Bienvenida</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/presentacion" data-drupal-link-system-path="node/31494">Presentación</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/comision-permanente" data-drupal-link-system-path="node/29478">Comisión Permanente</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/politica-panhispanica" data-drupal-link-system-path="node/31648">Política panhispánica</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/actividad-institucional" data-drupal-link-system-path="node/31515">Actividad institucional</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/biblioteca-de-la-asale" data-drupal-link-system-path="node/31634">Biblioteca de la ASALE</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/conmemoraciones" data-drupal-link-system-path="node/31641">Conmemoraciones</a>
+        
+
+              </li>
+      </ul>
+    
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/academias" data-drupal-link-system-path="academias">Academias</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <div class="parent-item">
+            <a href="/obras" data-drupal-link-system-path="node/29030">Obras</a>
+            <span class="menu-collapse">
+              <svg class="icon icon--xsmall icon-black">
+                <title>Abrir submenu</title>
+                <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-bottom"></use>
+              </svg>
+            </span>
+          </div>
+        
+
+                                <ul>
+              <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/diccionarios" data-drupal-link-system-path="taxonomy/term/100">Diccionarios</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/gramatica" data-drupal-link-system-path="taxonomy/term/101">Gramática</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/ortografia" data-drupal-link-system-path="taxonomy/term/102">Ortografía</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/ediciones-conmemorativas" data-drupal-link-system-path="taxonomy/term/103">Ediciones conmemorativas</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/clasicos-asale" data-drupal-link-system-path="taxonomy/term/337">Clásicos ASALE</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/otras-obras" data-drupal-link-system-path="taxonomy/term/330">Otras obras</a>
+        
+
+              </li>
+      </ul>
+    
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/corpus" data-drupal-link-system-path="node/29037">Corpus</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <div class="parent-item">
+            <a href="/escuela-de-lexicografia" data-drupal-link-system-path="node/29044">Escuela de Lexicografía</a>
+            <span class="menu-collapse">
+              <svg class="icon icon--xsmall icon-black">
+                <title>Abrir submenu</title>
+                <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-bottom"></use>
+              </svg>
+            </span>
+          </div>
+        
+
+                                <ul>
+              <li class="menu-list__item" >
+
+                  <a href="/escuela-de-lexicografia/la-elh" data-drupal-link-system-path="node/32131">La ELH</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/escuela-de-lexicografia/master-de-lexicografia-hispanica-y-correccion-linguistica" data-drupal-link-system-path="node/88530">Máster</a>
+        
+
+              </li>
+      </ul>
+    
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/publicaciones" data-drupal-link-system-path="node/28988">Publicaciones</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/noticias" data-drupal-link-system-path="noticias">Noticias</a>
+        
+
+              </li>
+      </ul>
+    
+
+
+  </nav>
+      </div>
+
+      <ul class="search-block">
+        <li class="menu-list__item link-dle">
+          <svg class="icon icon--tiny icon-white">
+            <title>Recursos</title>
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#diccionarios"></use>
+          </svg>
+          <span class="menu-list__text">Recursos</span>
+        </li>
+        <li class="menu-list__item link-search">
+          <svg class="icon icon--xsmall icon-white">
+            <title>Buscador</title>
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#lupa"></use>
+          </svg>
+        </li>
+        <li class="menu-list__item link-menu">
+          <svg class="icon icon--small icon-white">
+            <title>Menu</title>
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#menu"></use>
+          </svg>
+        </li>
+      </ul>
+
+    </nav>
+  </div>
+</header>
+<div class="container">
+<div class="row">
+<div class="col-xs-12 col-md-8" style="border-right:1px solid #ccc">  
+<div style="margin: 20px 0 10px 0;font-size:2em"><a href="/damer/">Diccionario de americanismos</a></div>
+<div class="form-box-wrapper">
+<div class="form-box"><form action="#" method="post" class="form form-damer" id="formulario"><input size="30" style="border:1px solid #ccc" class="custom-search-box" name="w" id="wq" type="text" value="" placeholder="Escriba aquí la palabra" autocomplete="off" autocapitalize="off"/><input style="margin-left:5px" alt="Buscar" type="image" class="icon icon--xsmall icon-grey" src="/themes/custom/front/src/assets/images/lupa.svg" name="submit"></form></div>
+<div class="addtext"><a style="" href="javascript:addText('á','damer');">á</a><a style="" href="javascript:addText('é','damer');">é</a><a style="" href="javascript:addText('í','damer');">í</a><a style="" href="javascript:addText('ó','damer');">ó</a><a style="" href="javascript:addText('ú','damer');">ú</a><a style="" href="javascript:addText('ü','damer');">ü</a><a style="" href="javascript:addText('ñ','damer');">ñ</a></div>
+</div>
+
+<div class="bloque-txt" id="resultados">
+<entry xmlns="http://www.w3.org/1999/xhtml" header="asopado" key="asopado" id="YqbRL3XoJx0AY6L6LUN">
+<table class="da4"><tr><td colspan="5" class="da2"><span class="da8">asopado.</span></td></tr><tr><td> </td><td class="da7"><span class="da3">I.</span></td><td class="da7"><span class="da3">1.</span></td><td colspan="2" class="da6">m. <i><span class="da5">Pa.</span></i><span class="da5"> Plato de arroz cocido con carne o pollo y algunas verduras, con la apariencia de una sopa espesa.</span></td></tr></table>
+</entry>
+
+<entry xmlns="http://www.w3.org/1999/xhtml" header="asopado, da" key="asopado|asopada" id="0fJiJWSBax0AahpCyw7" origHeader="asopado, -a.">
+<table class="da4"><tr><td colspan="5" class="da2"><span class="da8">asopado, -a.</span></td></tr><tr><td> </td><td class="da7"><span class="da3">I.</span></td><td class="da7"><span class="da3">1.</span></td><td colspan="2" class="da6">adj/sust. <i><span class="da5">Ch.</span></i> <i><span class="da5">Referido a persona</span></i><span class="da5">, escasa de entendimiento y lenta </span><span class="da0">para reaccionar</span><span class="da5">. pop + cult &#x2192; espon ^ desp.</span></td></tr></table>
+</entry>
+<p class="o"><center><i><span class="d7">Diccionario de americanismos © 2010<br/>Asociación de Academias de la Lengua Española © Todos los derechos reservados</span></i></center></p><div class="compartir"><a title="Compartir en Facebook" class="resp-sharing-button__link" href="https://facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fasopado" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--facebook resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M18.77 7.46H14.5v-1.9c0-.9.6-1.1 1-1.1h3V.5h-4.33C10.24.5 9.5 3.44 9.5 5.32v2.15h-3v4h3v12h5v-12h3.85l.42-4z"/></svg></div></div></a>
+<a title="Compartir en Twitter" class="resp-sharing-button__link" href="https://twitter.com/intent/tweet/?text=asopado, asopada - Diccionario de americanismos&url=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fasopado" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--twitter resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M23.44 4.83c-.8.37-1.5.38-2.22.02.93-.56.98-.96 1.32-2.02-.88.52-1.86.9-2.9 1.1-.82-.88-2-1.43-3.3-1.43-2.5 0-4.55 2.04-4.55 4.54 0 .36.03.7.1 1.04-3.77-.2-7.12-2-9.36-4.75-.4.67-.6 1.45-.6 2.3 0 1.56.8 2.95 2 3.77-.74-.03-1.44-.23-2.05-.57v.06c0 2.2 1.56 4.03 3.64 4.44-.67.2-1.37.2-2.06.08.58 1.8 2.26 3.12 4.25 3.16C5.78 18.1 3.37 18.74 1 18.46c2 1.3 4.4 2.04 6.97 2.04 8.35 0 12.92-6.92 12.92-12.93 0-.2 0-.4-.02-.6.9-.63 1.96-1.22 2.56-2.14z"/></svg></div></div></a>
+<a title="Compartir por correo electrónico" class="resp-sharing-button__link" href="/cdn-cgi/l/email-protection#e1de9294838b848295dc80928e9180858ecdc180928e91808580c1ccc1a5888282888e8f8093888ec18584c1808c84938882808f88928c8e92c7838e8598dc8995959192dbcece969696cf8092808d84cf8e9386ce85808c8493ce80928e9180858ec4d1a0c4d1a0a8cfc1d0cfc1b180cfc1b18d80958ec18584c18093938e9bc1828e8288858ec1828e8fc18280938f84c18ec1918e8d8d8ec198c1808d86948f8092c19784938594938092cdc1828e8fc18d80c18091809388848f828880c18584c1948f80c1928e9180c1849291849280cfc1a8cfc1d0cfc1a289cfc1b38487849388858ec180c1918493928e8f80c1cdc1849282809280c18584c1848f95848f85888c88848f958ec198c18d848f9580c1cfc1918e91c1cac182948d95c1036773c18492918e8fc1bfc185849291cf" target="_self" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--email resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M22 4H2C.9 4 0 4.9 0 6v12c0 1.1.9 2 2 2h20c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zM7.25 14.43l-3.5 2c-.08.05-.17.07-.25.07-.17 0-.34-.1-.43-.25-.14-.24-.06-.55.18-.68l3.5-2c.24-.14.55-.06.68.18.14.24.06.55-.18.68zm4.75.07c-.1 0-.2-.03-.27-.08l-8.5-5.5c-.23-.15-.3-.46-.15-.7.15-.22.46-.3.7-.14L12 13.4l8.23-5.32c.23-.15.54-.08.7.15.14.23.07.54-.16.7l-8.5 5.5c-.08.04-.17.07-.27.07zm8.93 1.75c-.1.16-.26.25-.43.25-.08 0-.17-.02-.25-.07l-3.5-2c-.24-.13-.32-.44-.18-.68s.44-.32.68-.18l3.5 2c.24.13.32.44.18.68z"/></svg></div></div></a>
+<a title="Compartir en WhatsApp" class="resp-sharing-button__link" href="whatsapp://send?text=asopado, asopada - Diccionario de americanismos%20https%3A%2F%2Fwww.asale.org%2Fdamer%2Fasopado" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--whatsapp resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20.1 3.9C17.9 1.7 15 .5 12 .5 5.8.5.7 5.6.7 11.9c0 2 .5 3.9 1.5 5.6L.6 23.4l6-1.6c1.6.9 3.5 1.3 5.4 1.3 6.3 0 11.4-5.1 11.4-11.4-.1-2.8-1.2-5.7-3.3-7.8zM12 21.4c-1.7 0-3.3-.5-4.8-1.3l-.4-.2-3.5 1 1-3.4L4 17c-1-1.5-1.4-3.2-1.4-5.1 0-5.2 4.2-9.4 9.4-9.4 2.5 0 4.9 1 6.7 2.8 1.8 1.8 2.8 4.2 2.8 6.7-.1 5.2-4.3 9.4-9.5 9.4zm5.1-7.1c-.3-.1-1.7-.9-1.9-1-.3-.1-.5-.1-.7.1-.2.3-.8 1-.9 1.1-.2.2-.3.2-.6.1s-1.2-.5-2.3-1.4c-.9-.8-1.4-1.7-1.6-2-.2-.3 0-.5.1-.6s.3-.3.4-.5c.2-.1.3-.3.4-.5.1-.2 0-.4 0-.5C10 9 9.3 7.6 9 7c-.1-.4-.4-.3-.5-.3h-.6s-.4.1-.7.3c-.3.3-1 1-1 2.4s1 2.8 1.1 3c.1.2 2 3.1 4.9 4.3.7.3 1.2.5 1.6.6.7.2 1.3.2 1.8.1.6-.1 1.7-.7 1.9-1.3.2-.7.2-1.2.2-1.3-.1-.3-.3-.4-.6-.5z"/></svg></div></div></a>
+<a title="Compartir en Telegram" class="resp-sharing-button__link" href="https://telegram.me/share/url?text=asopado, asopada - Diccionario de americanismos&url=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fasopado" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--telegram resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M.707 8.475C.275 8.64 0 9.508 0 9.508s.284.867.718 1.03l5.09 1.897 1.986 6.38a1.102 1.102 0 0 0 1.75.527l2.96-2.41a.405.405 0 0 1 .494-.013l5.34 3.87a1.1 1.1 0 0 0 1.046.135 1.1 1.1 0 0 0 .682-.803l3.91-18.795A1.102 1.102 0 0 0 22.5.075L.706 8.475z"/></svg></div></div></a>
+<a title="Compartir en Pinterest" class="resp-sharing-button__link" href="https://pinterest.com/pin/create/button/?url=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fasopado&media=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fasopado&description=I. 1. Pa. Plato de arroz cocido con carne o pollo y algunas verduras, con la apariencia de una sopa espesa. I. 1. Ch. Referido a persona , escasa de entendimiento y lenta . pop + cult → espon ^ desp." target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--pinterest resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.14.5C5.86.5 2.7 5 2.7 8.75c0 2.27.86 4.3 2.7 5.05.3.12.57 0 .66-.33l.27-1.06c.1-.32.06-.44-.2-.73-.52-.62-.86-1.44-.86-2.6 0-3.33 2.5-6.32 6.5-6.32 3.55 0 5.5 2.17 5.5 5.07 0 3.8-1.7 7.02-4.2 7.02-1.37 0-2.4-1.14-2.07-2.54.4-1.68 1.16-3.48 1.16-4.7 0-1.07-.58-1.98-1.78-1.98-1.4 0-2.55 1.47-2.55 3.42 0 1.25.43 2.1.43 2.1l-1.7 7.2c-.5 2.13-.08 4.75-.04 5 .02.17.22.2.3.1.14-.18 1.82-2.26 2.4-4.33.16-.58.93-3.63.93-3.63.45.88 1.8 1.65 3.22 1.65 4.25 0 7.13-3.87 7.13-9.05C20.5 4.15 17.18.5 12.14.5z"/></svg></div></div></a>
+<a title="Compartir en LinkedIn" class="resp-sharing-button__link" href="https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fasopado&title=asopado, asopada - Diccionario de americanismos&summary=I. 1. Pa. Plato de arroz cocido con carne o pollo y algunas verduras, con la apariencia de una sopa espesa. I. 1. Ch. Referido a persona , escasa de entendimiento y lenta . pop + cult → espon ^ desp.&source=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fasopado" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--linkedin resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
+<svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M6.5 21.5h-5v-13h5v13zM4 6.5C2.5 6.5 1.5 5.3 1.5 4s1-2.4 2.5-2.4c1.6 0 2.5 1 2.6 2.5 0 1.4-1 2.5-2.6 2.5zm11.5 6c-1 0-2 1-2 2v7h-5v-13h5V10s1.6-1.5 4-1.5c3 0 5 2.2 5 6.3v6.7h-5v-7c0-1-1-2-2-2z"/></svg></div></div></a></div></div>
+</div>
+<div data-nosnippet class="col-xs-12 col-md-4 bloque-txt">
+<h2 class="ayuda">Más información</h2>
+<div class="view-node-navigation"><ul class="menu"><li class="leaf d0"><a target="_blank" title="Prólogo de la obra" class="tooltip" href="https://www.asale.org/sites/default/files/Prologo_Diccionario_de_americanismos.pdf">Prólogo</a> de la obra</li><li class="leaf d0"><a target="_blank" title="Preliminares (abreviaturas) de la obra" class="tooltip" href="https://www.asale.org/sites/default/files/Abreviaturas_del_DA.pdf">Preliminares</a> (abreviaturas) de la obra</li></ul></div>
+
+		
+<div><h2 class="ayuda">Rueda de palabras</h2>
+<div>
+<ul class='rueda'><li><a href='/damer/asomante'>asomante</a></li><li><a href='/damer/asomar'>asomar</a></li><li><a href='/damer/asombrada'>asombrada</a></li><li><a href='/damer/asombrado'>asombrado</a></li><li><a href='/damer/asoñada'>asoñada</a></li><li><a href='/damer/asoñado'>asoñado</a></li><li><a href='/damer/asopada'>asopada</a></li><li><b>asopado</b></li><li><a href='/damer/asopao'>asopao</a></li><li><a href='/damer/asorochada'>asorochada</a></li><li><a href='/damer/asorochado'>asorochado</a></li><li><a href='/damer/asorochamiento'>asorochamiento</a></li><li><a href='/damer/asorochar'>asorochar</a></li><li><a href='/damer/asorocharse'>asorocharse</a></li><li><a href='/damer/asortijada'>asortijada</a></li></ul></div>
+</div>
+</div>
+</div>
+</div>
+<div data-nosnippet class="clearfix" id="main">
+    <div data-nosnippet class="cog--mq mq-main">
+
+            <section class="section section--secondary o-section--large">
+  <div data-nosnippet class="container">
+
+    <h2 class="section__title" data-aos="fade-up" data-aos-offset="50" data-aos-delay="200" data-aos-duration="1000">
+      <span class="divider__title"></span>
+      También le interesará
+    </h2>
+
+    <div data-nosnippet class="row">
+
+      <div data-nosnippet class="col-xs-12 col-md-6 col-lg-3"
+           data-aos="fade-up"
+           data-aos-offset="150"
+           data-aos-delay="400"
+           data-aos-duration="800">
+          <div data-nosnippet class="views-element-container">
+<div data-nosnippet class="js-view-dom-id-02a2d65813f4ad19486655be44ae3d013bf874ea18cdb029038d81b8f502454b vista">
+    
+    
+    
+
+    
+    
+    
+
+    
+
+  
+
+<div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/noticia/la-asociacion-de-academias-de-la-lengua-espanola-celebra-su-70o-aniversario-bajo-la">70 AÑOS DE ASALE</a></p>
+
+      <div data-nosnippet class="block-news__img img">
+      <a target="_self" title="Actos de celebración del 70 aniversario" href="/noticia/la-asociacion-de-academias-de-la-lengua-espanola-celebra-su-70o-aniversario-bajo-la">
+        <img class="b-lazy"
+             src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+             data-src="/sites/default/files/styles/tambien_interesa/public/2021-12/70%20anos%20asale.jpg?itok=kU8Y2JlT"
+             alt="Los reyes de España han presidido en el salón de actos de la RAE el solemne acto institucional conmemorativo del septuagésimo aniversario de la Asociación de Academias de la Lengua Española (ASALE). Foto: RAE. " />
+      </a>
+    </div>
+  
+      <span class="news__date">
+      
+    </span>
+  
+  <p class="block-news__title u-text-brandsecondary">
+    <a target="_self" title="Actos de celebración del 70 aniversario" href="/noticia/la-asociacion-de-academias-de-la-lengua-espanola-celebra-su-70o-aniversario-bajo-la">
+      Actos de celebración del 70 aniversario
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+
+  
+
+<div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/obras-academicas/clasicos-asale">Clásicos ASALE</a></p>
+
+      <div data-nosnippet class="block-news__img img">
+      <a target="_self" title="Conozca los títulos de toda la colección" href="/obras-academicas/clasicos-asale">
+        <img class="b-lazy"
+             src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+             data-src="/sites/default/files/styles/tambien_interesa/public/imagenes/articulos/Foto_La_Voz_de_Galicia_1_1.png?itok=nG30FJfh"
+             alt="Nuevos títulos de la colección Clásicos ASALE  " />
+      </a>
+    </div>
+  
+      <span class="news__date">
+      
+    </span>
+  
+  <p class="block-news__title u-text-brandsecondary">
+    <a target="_self" title="Conozca los títulos de toda la colección" href="/obras-academicas/clasicos-asale">
+      Conozca los títulos de toda la colección
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+
+        
+
+    
+    
+
+    
+</div>
+</div>
+
+      </div>
+
+
+      <div data-nosnippet class="col-xs-12 col-md-6 col-lg-8 u-border-left"
+           data-aos="fade-up"
+           data-aos-offset="150"
+           data-aos-delay="400"
+           data-aos-duration="800">
+          <div data-nosnippet class="views-element-container">
+<div data-nosnippet class="js-view-dom-id-b5df2b64bbf6d0641e267cd9ab9d13eb19064524d5085d5ec1cde593ffb30d5b vista">
+    
+    
+    
+
+    
+    
+    
+
+    
+<div data-nosnippet class="row">
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/lexicografia" hreflang="es">Lexicografía</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Cuarta convocatoria del Programa ASALE de becas de formación y colaboración destinado a las academias de la Asociación de Academias de la Lengua Española (ASALE) " href="/noticia/cuarta-convocatoria-del-programa-asale-de-becas-de-formacion-y-colaboracion-destinado-las">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/imagenes/articulos/centro_de_estudios_RAE_serrano.jpg?h=c9f93661&amp;itok=zfPMAJv-"
+               alt="Sede de la Escuela de Lexicografía (Serrano, 187-189) en Madrid (foto: RAE)">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2025-05-27T12:00:00Z">27 de Mayo de 2025</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Cuarta convocatoria del Programa ASALE de becas de formación y colaboración destinado a las academias de la Asociación de Academias de la Lengua Española (ASALE) " href="/noticia/cuarta-convocatoria-del-programa-asale-de-becas-de-formacion-y-colaboracion-destinado-las">
+      <span>Cuarta convocatoria del Programa ASALE de becas de formación y colaboración destinado a las academias de la Asociación de Academias de la Lengua Española (ASALE) </span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/academicos" hreflang="es">Académicos</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Carlos Martini, nuevo miembro de número de la Academia Paraguaya de la Lengua Española" href="/noticia/carlos-martini-nuevo-miembro-de-numero-de-la-academia-paraguaya-de-la-lengua-espanola">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/2021-11/Sede_APARLE.jpg?h=9e499333&amp;itok=BhYtrdjy"
+               alt="Sede de la Academia Paraguaya de la Lengua Española">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2025-01-13T12:00:00Z">13 de Enero de 2025</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Carlos Martini, nuevo miembro de número de la Academia Paraguaya de la Lengua Española" href="/noticia/carlos-martini-nuevo-miembro-de-numero-de-la-academia-paraguaya-de-la-lengua-espanola">
+      <span>Carlos Martini, nuevo miembro de número de la Academia Paraguaya de la Lengua Española</span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/obituarios" hreflang="es">Obituarios</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Fallece Tarsicio Herrera Zapién, miembro de la Academia Mexicana de la Lengua" href="/noticia/fallece-tarsicio-herrera-zapien-miembro-de-la-academia-mexicana-de-la-lengua">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/imagenes/academicos/Tarsicio_Herrera_Sapien_www.cultura.gob_.mx_.jpg?h=c9f93661&amp;itok=XE1zuFdY"
+               alt="Tarsicio Herrera Zapién, miembro de número de la Academia Mexicana de la Lengua. Foto: Secretaría de Cultura.">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2026-02-05T12:00:00Z">5 de Febrero de 2026</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Fallece Tarsicio Herrera Zapién, miembro de la Academia Mexicana de la Lengua" href="/noticia/fallece-tarsicio-herrera-zapien-miembro-de-la-academia-mexicana-de-la-lengua">
+      <span>Fallece Tarsicio Herrera Zapién, miembro de la Academia Mexicana de la Lengua</span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/academicos" hreflang="es">Académicos</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Félix Julio Alfonso López ingresa en la Academia Cubana de la Lengua" href="/noticia/felix-julio-alfonso-lopez-ingresa-en-la-academia-cubana-de-la-lengua">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/2026-02/F%C3%A9lix%20Julio%20Alfonso%20L%C3%B3pez_0.jpg?h=8b436e18&amp;itok=6lYXMiAr"
+               alt="Félix Julio Alfonso López">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2026-02-04T12:00:00Z">4 de Febrero de 2026</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Félix Julio Alfonso López ingresa en la Academia Cubana de la Lengua" href="/noticia/felix-julio-alfonso-lopez-ingresa-en-la-academia-cubana-de-la-lengua">
+      <span>Félix Julio Alfonso López ingresa en la Academia Cubana de la Lengua</span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+  </div>
+
+        
+
+    
+    
+
+    
+</div>
+</div>
+
+      </div>
+
+
+    </div>
+  </div>
+</section>
+
+            <section class="section o-section--medium">
+
+  <div data-nosnippet class="container">
+    <div data-nosnippet class="u-text-center">
+
+      <div data-nosnippet class="btn btn-up" data-aos="fade-up" data-aos-offset="50" data-aos-delay="200" data-aos-duration="1000">
+        <a href="#main" class="ancla">
+          <svg class="icon icon--small icon-black">
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-up"></use>
+          </svg>
+          <p class="btn__text">Arriba</p>
+        </a>
+      </div>
+
+    </div>
+  </div>
+
+</section>
+
+    </div>
+  </div>
+
+  
+  <footer id="footer" class="footer">
+  <div data-nosnippet class="container">
+    <div data-nosnippet class="pre-footer">
+
+      <p class="footer-privacidad">
+        REAL ACADEMIA ESPAÑOLA. Finalidades: Recopilación de información lingüística para la investigación, desarrollo, proyección y buen uso de la lengua española en el ámbito de la IA (proyecto LEIA). Derechos: tiene derecho a acceder, rectificar y suprimir sus datos, así como a otros derechos como se explica en la información adicional y detallada que se puede consultar en nuestra 
+        <span class="privacidad-link privacidad-link--inverse"><a href="/politica-de-privacidad-y-proteccion-de-los-datos-personales" target="_blank">política de privacidad</a>.</span>
+      </p>
+
+    </div>
+
+    <div data-nosnippet class="sub-footer">
+      <div data-nosnippet class="sub-footer__social">
+        <a title="Síganos en X" href="https://x.com/RAEinforma" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en X</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#twitter"></use>
+    </svg>
+</a>
+<a title="Síganos en Facebook"  href="https://www.facebook.com/RAE/" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en Facebook</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#facebook"></use>
+    </svg>
+</a>
+<a title="Visite nuestro Instagram" href="https://www.instagram.com/laraeinforma/" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Visite nuestro Instagram</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#instagram"></use>
+    </svg>
+</a>
+<a title="Síganos en TikTok" href="https://www.tiktok.com/@rae.informa" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en TikTok</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#tiktok"></use>
+    </svg>
+</a>
+<a title="Visite nuestras galerías" href="https://www.flickr.com/photos/raeinforma" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Visite nuestras galerías</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#flicker"></use>
+    </svg>
+</a>
+<a title="Síganos en Youtube" href="https://www.youtube.com/user/RAEInforma" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en Youtube</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#youtube"></use>
+    </svg>
+</a>
+
+<a title="Escuche nuestras listas de música" href="https://open.spotify.com/user/u0gt78txho8qqa5m843kkvxy2" rel="noopener" target="_blank">
+  <svg class="icon icon--medium">
+    <title>Escuche nuestras listas de música</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#spoty"></use>
+  </svg>
+</a>
+
+<a title="Síganos en Souncloud" href="https://soundcloud.com/real-academia-espanola" rel="noopener" target="_blank">
+  <svg class="icon icon--medium">
+    <title>Síganos en Soundcloud</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#soundcloud"></use>
+  </svg>
+</a>
+
+<a title="Contacte con nosotros" href="/contacto-rae">
+	<svg class="icon icon--medium">
+		<title>Contacte con nosotros</title>
+		<use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#email"></use>
+	</svg>
+</a>
+
+      </div>
+
+      <div data-nosnippet class="sub-footer__link">
+        <a title="Visitar Fundación pro-RAE" href="/fundacion">Fundación pro-Rae</a>
+        <a title="Visitar web ASALE" href="https://www.asale.org/" rel="noopener" target="_blank">Asale</a>
+      </div>
+
+
+      <p class="footer__text">
+        Felipe IV, 5 - 28014 Madrid - Teléfono:
+        <a title="Teléfono contacto" href="tel:34914201478">+34 91 420 14 78</a>
+        <span class="ml-1 d-inline-block">
+          © Real Academia Española, 2019
+        </span>
+      </p>
+
+      
+
+<nav role="navigation" aria-labelledby="block-piedepagina" id="block-piedepagina" class="block block-menu navigation block-system-menublock menu--footer">
+      
+        
+
+                        <ul class="footer-list">
+                            <li class="footer-list__item">
+                <a href="https://rae.whistlelink.com" target="_blank">Canal del informante</a>
+                            </li>
+                </ul>
+    
+
+
+  </nav>
+
+    </div>
+
+  </div>
+</footer>
+
+<div data-nosnippet class="search-full-container">
+  <span class="menu-buttom__close">
+  <svg class="icon icon--xsmall icon-black">
+    <title>cerrar</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#close"></use>
+  </svg>
+</span>
+  <div data-nosnippet class="container">
+
+    <div data-nosnippet class="header__logo">
+      <div data-nosnippet class="img">
+        <a href="/" title="Inicio - Real Academia Española" rel="home" class="site-logo">
+          <svg class="icon icon-logo">
+            <title>Logo RAE</title>
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#logo-rae"></use>
+          </svg>
+        </a>
+      </div>
+    </div>
+    <div data-nosnippet class="row justify-content-center">
+      <div data-nosnippet class="col-12 col-md-8">
+        <h2 class="search__title">Buscador general de la RAE</h2>
+
+        <form class="search-block-form" data-drupal-selector="search-block-form" action="/search/node" method="get" id="search-block-form" accept-charset="UTF-8">
+  <div data-nosnippet class="js-form-item form-item js-form-type-search form-type-search js-form-item-keys form-item-keys form-no-label">
+      <label for="edit-keys" class="visually-hidden">Search</label>
+        <input title="Escriba lo que quiere buscar." placeholder="Buscar en la web" data-drupal-selector="edit-keys" type="search" id="edit-keys" name="keys" value="" size="15" maxlength="128" class="form-search" />
+
+        </div>
+<div data-nosnippet data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions"><input alt="Buscar en la web" data-drupal-selector="edit-submit" type="image" id="edit-submit" name="op" src="/themes/custom/front/src/assets/images/lupa.svg" class="image-button js-form-submit form-submit" />
+</div>
+
+</form>
+
+      </div>
+    </div>
+  </div>
+</div>
+
+<div data-nosnippet class="dle-full-container">
+  <span class="menu-buttom__close">
+  <svg class="icon icon--xsmall icon-black">
+    <title>cerrar</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#close"></use>
+  </svg>
+</span>
+  <div data-nosnippet class="contenedor-full">
+
+    <div data-nosnippet class="container">
+      <div data-nosnippet class="row justify-content-between">
+
+        <div data-nosnippet class="col-xs-12 col-lg-7">
+          <div data-nosnippet class="diccionarios-container">
+            <h2 class="diccionarios-container__title">Diccionarios</h2>
+            <form class="diccionarios-form" data-drupal-selector="diccionarios-form" action="/" method="post" id="diccionarios-form" accept-charset="UTF-8">
+  <div data-nosnippet id="edit-diccionario"><div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dle" type="radio" id="edit-diccionario-dle" name="diccionario" value="dle" checked="checked" class="form-radio" />
+
+        <label for="edit-diccionario-dle" class="option">Diccionario de la lengua española</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dpd" type="radio" id="edit-diccionario-dpd" name="diccionario" value="dpd" class="form-radio" />
+
+        <label for="edit-diccionario-dpd" class="option">Diccionario panhispánico de dudas</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dpej" type="radio" id="edit-diccionario-dpej" name="diccionario" value="dpej" class="form-radio" />
+
+        <label for="edit-diccionario-dpej" class="option">Diccionario panhispánico del español jurídico</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dhle" type="radio" id="edit-diccionario-dhle" name="diccionario" value="dhle" class="form-radio" />
+
+        <label for="edit-diccionario-dhle" class="option">Diccionario histórico de la lengua española</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-damer" type="radio" id="edit-diccionario-damer" name="diccionario" value="damer" class="form-radio" />
+
+        <label for="edit-diccionario-damer" class="option">Diccionario de americanismos</label>
+      </div>
+</div>
+<fieldset data-drupal-selector="edit-caja" id="edit-caja" class="form-item js-form-wrapper form-wrapper">
+      <legend>
+    <span class="fieldset-legend"></span>
+  </legend>
+  <div data-nosnippet class="fieldset-wrapper">
+            <div data-nosnippet class="js-form-item form-item js-form-type-textfield form-type-textfield js-form-item-termino form-item-termino form-no-label">
+        <input aria-label="Término" data-drupal-selector="edit-termino" type="text" id="edit-termino" name="termino" value="" size="60" maxlength="128" placeholder="Escriba el término" class="form-text required" required="required" aria-required="true" />
+
+        </div>
+<input class="icon--small image-button js-form-submit form-submit" alt="Escriba el término" data-drupal-selector="edit-submit" type="image" id="edit-submit--2" name="op" src="/themes/custom/front/src/assets/images/lupa.svg" />
+
+          </div>
+</fieldset>
+<div data-nosnippet class="logo"><div data-nosnippet data-drupal-selector="edit-lacaixa-modal" data-drupal-states="{&quot;visible&quot;:[{&quot;:input[name=\u0022diccionario\u0022]&quot;:{&quot;value&quot;:&quot;dle&quot;}}]}" id="edit-lacaixa-modal" class="js-form-wrapper form-wrapper"><a title="Fundación “la Caixa”" rel="noopener" target="_blank" href="https://fundacionlacaixa.org/es/home"><img src="/themes/custom/front/src/assets/svg/logo-fundacion-caixa.svg" alt="Logo Obra social “la Caixa”"></a></div>
+</div><input autocomplete="off" data-drupal-selector="form-xia40oqp-xumj65oafjg5thtpkciat38yywr-l468i4" type="hidden" name="form_build_id" value="form-XIA40Oqp-xUMJ65oafjg5thtPkCIat38YyWR-l468I4" />
+<input data-drupal-selector="edit-diccionarios-form" type="hidden" name="form_id" value="diccionarios_form" />
+<div data-nosnippet data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions--3"></div>
+
+</form>
+
+          </div>
+        </div>
+        <div data-nosnippet class="col-xs-12 col-lg-4">
+          <div data-nosnippet class="dudas-container">
+            <h2 class="dudas-container__title">Dudas rápidas</h2>
+            <form class="dudas-form-modal" data-drupal-selector="dudas-form-modal" action="/" method="post" id="dudas-form-modal" accept-charset="UTF-8">
+  <fieldset data-drupal-selector="edit-caja-dudas-modal" id="edit-caja-dudas-modal" class="form-item js-form-wrapper form-wrapper">
+      <legend>
+    <span class="fieldset-legend"></span>
+  </legend>
+  <div data-nosnippet class="fieldset-wrapper">
+            <div data-nosnippet class="js-form-item form-item js-form-type-textfield form-type-textfield js-form-item-duda-modal form-item-duda-modal form-no-label">
+        <input aria-label="Término" data-drupal-selector="edit-duda-modal" type="text" id="edit-duda-modal" name="duda_modal" value="" size="60" maxlength="128" placeholder="Escriba las palabras clave" class="form-text required" required="required" aria-required="true" />
+
+        </div>
+<input class="icon--small image-button js-form-submit form-submit" alt="Buscar duda" data-drupal-selector="edit-submit-modal" type="image" id="edit-submit-modal" name="op" src="/themes/custom/front/src/assets/images/lupa.svg" />
+
+          </div>
+</fieldset>
+<input autocomplete="off" data-drupal-selector="form-cvfp2zsxkvagunug3dkccupvudyupyammxp4ka-jrzq" type="hidden" name="form_build_id" value="form-cvFP2zsxkVagunUg3dKcCupVUDYUPYAMMXp4kA-JRZQ" />
+<input data-drupal-selector="edit-dudas-form-modal" type="hidden" name="form_id" value="dudas_form_modal" />
+<div data-nosnippet data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions--5"></div>
+
+</form>
+
+          </div>
+        </div>
+      </div>
+
+      <div data-nosnippet class="recursos-container">
+        <h2 class="title__medium text-center mb-7">
+          Otros Recursos
+          <svg class="icon icon--xsmall icon-black">
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#plus"></use>
+          </svg>
+          <svg class="icon icon--xsmall icon-black hidden">
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#menos"></use>
+          </svg>
+        </h2>
+        <div data-nosnippet class="lista-recursos-container">
+          
+
+
+    
+          <ul class="lista-recursos" >
+    
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Diccionarios</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://dle.rae.es/">Diccionario de la lengua española</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/dpd/">Diccionario panhispánico de dudas</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://dpej.rae.es/">Diccionario panhispánico del español jurídico</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="/dhle">Diccionario histórico de la lengua española</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.asale.org/damer/">Diccionario de americanismos</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/diccionario-estudiante/" title="Diccionario del estudiante">Diccionario del estudiante</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/tdhle/" title="Tesoro de diccionarios históricos de la lengua">Tesoro de diccionarios históricos de la lengua</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/DA.html">Diccionario de autoridades</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://apps.rae.es/ntlle/SrvltGUISalirNtlle">Nuevo tesoro lexicográfico</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/ntllet/SrvltGUILoginNtlletPub">Mapa de diccionarios</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/DH1936.html">Diccionario histórico (1933-1936)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/DH.html">Diccionario histórico (1960-1996)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/drae2001/">Diccionario de la lengua española (2001)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/desen/">Diccionario esencial (2006)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/formulario-de-la-unidad-interactiva-del-diccionario" title="Envíe las propuestas y sugerencias externas relacionadas con el «Diccionario de la lengua española»">Unidad Interactiva del Diccionario (UNIDRAE)</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Banco de datos</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/corpes/">CORPES XXI</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/CNDHE/">CDH</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://corpus.rae.es/creanet.html">CREA</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/crea-anotado/" title="CREA anotado">CREA anotado</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://corpus.rae.es/cordenet.html">CORDE</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/fichero.html">Fichero general</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.asale.org/corpus-asale/">Corpus ASALE</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Gramática</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://aplica.rae.es/grweb/cgi-bin/buscar.cgi">Nueva gramática de la lengua española</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/gtg/">Glosario de términos gramaticales</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/sites/default/files/Gramatica_RAE_1771_reducida.pdf">Primera gramática</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/gram%C3%A1tica-b%C3%A1sica/" title="Nueva gramática básica de la lengua española">Nueva gramática básica de la lengua española</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Ortografía</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://aplica.rae.es/orweb/cgi-bin/buscar.cgi">Ortografía 2010</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="/sites/default/files/Ortografia_RAE_1741_reducida.pdf">Primera ortografía</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/ortograf%C3%ADa-b%C3%A1sica/" title="Ortografía básica de la lengua española">Ortografía básica de la lengua española</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Biblioteca</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca/biblioteca-academica">Biblioteca académica</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca/legado-antonio-rodriguez-monino-y-maria-brey">Legado Rodríguez-Moñino</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca/legado-damaso-alonso">Legado Dámaso Alonso</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca-digital" title="Biblioteca Digital">Biblioteca Digital</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Archivo</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://archivo.rae.es/">Fondo institucional</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://archivo.rae.es/index.php/coleccion-de-autografos-de-pedro-antonio-de-alarcon">Colección P. A. de Alarcón</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://archivo.rae.es/zorrilla/">Zorrilla</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/manuscritos-para-la-segunda-edicion-del-diccionario-de-autoridades">2.ª edición del «Diccionario de autoridades»</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://archivo.rae.es/fichero-de-hilo">Fichero de hilo</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Boletines</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://revistas.rae.es/bilrae/">BILRAE</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://revistas.rae.es/brae">BRAE</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span title="Recursos académicos de apoyo para el lenguaje claro">Lenguaje claro</span>
+          </div>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Enclave</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://enclavedeciencia.rae.es/inicio">Enclave de Ciencia</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Enlaces externos</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://asines.org/">Atlas sintáctico del español</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/dhecan.html">Diccionario Histórico del Español de Canarias</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/CORLEXIN.html">Corpus Léxico de Inventarios</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://lla.unileon.es/" title="Léxico leonés actual">Léxico leonés actual</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+    
+  </ul>
+  
+
+
+        </div>
+      </div>
+
+
+    </div>
+
+  </div>
+</div>
+
+</div>
+
+  </div>
+
+      
+
+    </div>
+
+    
+
+
+  <script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script src="/sites/default/files/js/js_7hSOT9HVKxMvGlrclR4TDcqOUtAR-0e88Vkq_P_PROE.js"></script>\n<script src="/damer/js/20210406.js"></script>
+<!--[if IE]>
+<style>
+#deletex{ display:none;}
+</style>
+<![endif]-->
+</body>
+<script>
+window.cat='EXTERNO';window.acc='www.asale.org/damer/asopado';window.eti='https://www.asale.org/damer/asopada';
+</script>
+</html>

--- a/tests/cogs/damer_sample_htmls/cajeta.html
+++ b/tests/cogs/damer_sample_htmls/cajeta.html
@@ -1,0 +1,1358 @@
+<!DOCTYPE html>
+<html lang="es">
+<head><noscript><style>form.antibot * :not(.antibot-message) { display: none !important; }</style></noscript>
+<link rel="preload" href="/sites/default/files/css/css_2toHNXfbnPicu5GM0gX9NZ5orfKOc_JkPXeCbZqaWws.css" as="style">
+<link rel="preload" href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&amp;display=swap" as="style">
+<link rel="preload" href="https://fonts.googleapis.com/css2?family=Merriweather:wght@700&amp;display=swap" as="style">
+<link rel="preload" href="/sites/default/files/css/css_MKU0IOMhjZnRGgSeMxmlSpwNVcEMZOFPTb3EZkC-BVI.css" as="style">
+<link rel="preload" href="/sites/default/files/js/js_7hSOT9HVKxMvGlrclR4TDcqOUtAR-0e88Vkq_P_PROE.js" as="script">
+<link rel="preload" href="/damer/css/20201019.css" as="style">
+<link rel="preload" href="/damer/js/20210406.js" as="script">
+<link rel="preload" href="/themes/custom/front/assets/fonts/lato/lato-bold-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/lato/lato-regular-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/merriweather/merriweather-black-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/merriweather/merriweather-light-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/merriweather/merriweather-regular-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="canonical" href="https://www.asale.org/damer/cajeta"/>
+<title>cajeta | Diccionario de americanismos | ASALE</title>
+<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="I. 1. Mx , Gu , Cu , RD , PR , Pe ; Ec, obsol; Ho , pop. Caja en que se ponen o venden dulces, jalea o turrón de diversas formas, según el molde que se use."/>
+<meta name="keywords" content="cajeta, definición de cajeta, significado de cajeta, ASALE, RAE"/>
+<meta name="author" content="ASALE"/>
+<meta name="robots" content="index,follow"/>
+<meta name="rating" content="safe for kids"/>
+<meta name="rights" content="Asociación de Academias de la Lengua Española © Todos los derechos reservados"/>
+<meta name="author" content="ASALE">
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:site" content="\@ASALEinforma"/>
+<meta name="twitter:url" content="https://www.asale.org/damer/cajeta"/>
+<meta name="twitter:title" content="cajeta | Diccionario de americanismos"/>
+<meta name="twitter:description" content="I. 1. Mx , Gu , Cu , RD , PR , Pe ; Ec, obsol; Ho , pop. Caja en que se ponen o venden dulces, jalea o turrón de diversas formas, según el molde que se use."/>
+<meta name="twitter:image" content="/damer/img/logo-asale.png"/>
+<meta name="twitter:image:alt" content="«Diccionario de americanismos»"/>
+<meta property="article:author" content="https://es-es.facebook.com/asale"/>
+<meta property="og:title" content="cajeta | Diccionario de americanismos"/>
+<meta property="og:type" content="website"/>
+<meta property="og:site_name" content="«Diccionario de americanismos»"/>
+<meta property="og:url" content="https://www.asale.org/damer/cajeta"/>
+<meta property="og:description" content="I. 1. Mx , Gu , Cu , RD , PR , Pe ; Ec, obsol; Ho , pop. Caja en que se ponen o venden dulces, jalea o turrón de diversas formas, según el molde que se use."/>
+<meta property="og:locale" content="es"/>
+<meta property="og:image" content="/damer/img/logo-asale.png"/>
+<meta property="og:image:type" content="image/png"/>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<link rel="shortcut icon" href="/themes/custom/front/favicon.ico" />
+<link rel="mask-icon" href="/themes/custom/front/src/assets/images/favicons/safari-pinned-tab.svg" />
+<link rel="icon" sizes="16x16" href="/themes/custom/front/src/assets/images/favicons/favicon-16x16.png" />
+<link rel="icon" sizes="32x32" href="/themes/custom/front/src/assets/images/favicons/favicon-32x32.png" />
+<link rel="apple-touch-icon" sizes="180x180" href="/themes/custom/front/src/assets/images/favicons/apple-touch-icon.png" />
+<link rel="apple-touch-icon-precomposed" sizes="180x180" href="/themes/custom/front/src/assets/images/favicons/apple-touch-icon.png" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=2, minimum-scale=1, user-scalable=yes" />
+<!--[if lt IE 9]><script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+<script type="application/ld+json">
+[{"@context": "http://schema.org/"},{"@type": ["DefinedTermSet","Book"],"@id": "https://www.asale.org/damer","name": "Diccionario de americanismos RAE - ASALE","image": "https://www.asale.org/damer/img/logo-asale.png","description": "Versión electrónica del «Diccionario de americanismos»."},{"@type": "DefinedTerm","@id": "https://www.asale.org/damer/cajeta","name": "cajeta","description": "I. 1. Mx , Gu , Cu , RD , PR , Pe ; Ec, obsol; Ho , pop. Caja en que se ponen o venden dulces, jalea o turrón de diversas formas, según el molde que se use.","inDefinedTermSet": "https://www.asale.org/damer"}]
+</script><link rel="stylesheet" media="all" href="/sites/default/files/css/css_2toHNXfbnPicu5GM0gX9NZ5orfKOc_JkPXeCbZqaWws.css"/>
+<link rel="stylesheet" media="all" href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&amp;display=swap"/>
+<link rel="stylesheet" media="all" href="https://fonts.googleapis.com/css2?family=Merriweather:wght@700&amp;display=swap"/>
+<link rel="stylesheet" media="all" href="/sites/default/files/css/css_MKU0IOMhjZnRGgSeMxmlSpwNVcEMZOFPTb3EZkC-BVI.css"/>
+<script>window.a2a_config=window.a2a_config||{};a2a_config.callbacks=[];a2a_config.overlays=[];a2a_config.templates={};a2a_config.static_server= "http://www.asale.org/sites/default/files/addtoany/menu/oafg07ee";a2a_config.icon_color = "transparent,#000";</script>
+
+<link rel="stylesheet" media="all" href="/damer/css/20201019.css"/>
+</head>
+<body class="path--node body-sidebars-none alias--noticia-primera-reunion-plenaria-virtual-de-directores-y-presidentes-de-las-academias-de-la-lengua nodetype--noticia logged-out" data-aos-easing="ease" data-aos-duration="400" data-aos-delay="0">
+<div role="main">
+<div class="dialog-off-canvas-main-canvas" data-off-canvas-main-canvas="">
+<div class="page-standard" id="pg__c">
+
+<header id="header" class="header">
+
+  <div class="header__logo">
+    <div class="img">
+                <a href="/" title="Inicio - ASALE" rel="home" class="site-logo">
+            <img src="/themes/custom/asale/assets/images/logo-asale.png" alt="Logo ASALE"/>
+          </a>
+          </div>
+  </div>
+
+  <div class="header-menu-search">
+
+    <nav class="header-menu">
+
+      <div class="main-menu-container">
+        <span class="menu-buttom__close">
+  <svg class="icon icon--xsmall icon-black">
+    <title>cerrar</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#close"></use>
+  </svg>
+</span>
+        
+
+<nav role="navigation" aria-labelledby="block-navegacionprincipalasale" id="block-navegacionprincipalasale" class="block block-menu navigation block-system-menublock menu--main-asale">
+      
+        
+
+
+              <ul class="menu-list main">
+              <li class="menu-list__item" >
+
+                  <div class="parent-item">
+            <a href="/la-asociacion" data-drupal-link-system-path="node/29051">La Asociación</a>
+            <span class="menu-collapse">
+              <svg class="icon icon--xsmall icon-black">
+                <title>Abrir submenu</title>
+                <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-bottom"></use>
+              </svg>
+            </span>
+          </div>
+        
+
+                                <ul>
+              <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/bienvenida" data-drupal-link-system-path="node/31480">Bienvenida</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/presentacion" data-drupal-link-system-path="node/31494">Presentación</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/comision-permanente" data-drupal-link-system-path="node/29478">Comisión Permanente</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/politica-panhispanica" data-drupal-link-system-path="node/31648">Política panhispánica</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/actividad-institucional" data-drupal-link-system-path="node/31515">Actividad institucional</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/biblioteca-de-la-asale" data-drupal-link-system-path="node/31634">Biblioteca de la ASALE</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/conmemoraciones" data-drupal-link-system-path="node/31641">Conmemoraciones</a>
+        
+
+              </li>
+      </ul>
+    
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/academias" data-drupal-link-system-path="academias">Academias</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <div class="parent-item">
+            <a href="/obras" data-drupal-link-system-path="node/29030">Obras</a>
+            <span class="menu-collapse">
+              <svg class="icon icon--xsmall icon-black">
+                <title>Abrir submenu</title>
+                <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-bottom"></use>
+              </svg>
+            </span>
+          </div>
+        
+
+                                <ul>
+              <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/diccionarios" data-drupal-link-system-path="taxonomy/term/100">Diccionarios</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/gramatica" data-drupal-link-system-path="taxonomy/term/101">Gramática</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/ortografia" data-drupal-link-system-path="taxonomy/term/102">Ortografía</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/ediciones-conmemorativas" data-drupal-link-system-path="taxonomy/term/103">Ediciones conmemorativas</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/clasicos-asale" data-drupal-link-system-path="taxonomy/term/337">Clásicos ASALE</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/otras-obras" data-drupal-link-system-path="taxonomy/term/330">Otras obras</a>
+        
+
+              </li>
+      </ul>
+    
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/corpus" data-drupal-link-system-path="node/29037">Corpus</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <div class="parent-item">
+            <a href="/escuela-de-lexicografia" data-drupal-link-system-path="node/29044">Escuela de Lexicografía</a>
+            <span class="menu-collapse">
+              <svg class="icon icon--xsmall icon-black">
+                <title>Abrir submenu</title>
+                <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-bottom"></use>
+              </svg>
+            </span>
+          </div>
+        
+
+                                <ul>
+              <li class="menu-list__item" >
+
+                  <a href="/escuela-de-lexicografia/la-elh" data-drupal-link-system-path="node/32131">La ELH</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/escuela-de-lexicografia/master-de-lexicografia-hispanica-y-correccion-linguistica" data-drupal-link-system-path="node/88530">Máster</a>
+        
+
+              </li>
+      </ul>
+    
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/publicaciones" data-drupal-link-system-path="node/28988">Publicaciones</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/noticias" data-drupal-link-system-path="noticias">Noticias</a>
+        
+
+              </li>
+      </ul>
+    
+
+
+  </nav>
+      </div>
+
+      <ul class="search-block">
+        <li class="menu-list__item link-dle">
+          <svg class="icon icon--tiny icon-white">
+            <title>Recursos</title>
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#diccionarios"></use>
+          </svg>
+          <span class="menu-list__text">Recursos</span>
+        </li>
+        <li class="menu-list__item link-search">
+          <svg class="icon icon--xsmall icon-white">
+            <title>Buscador</title>
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#lupa"></use>
+          </svg>
+        </li>
+        <li class="menu-list__item link-menu">
+          <svg class="icon icon--small icon-white">
+            <title>Menu</title>
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#menu"></use>
+          </svg>
+        </li>
+      </ul>
+
+    </nav>
+  </div>
+</header>
+<div class="container">
+<div class="row">
+<div class="col-xs-12 col-md-8" style="border-right:1px solid #ccc">  
+<div style="margin: 20px 0 10px 0;font-size:2em"><a href="/damer/">Diccionario de americanismos</a></div>
+<div class="form-box-wrapper">
+<div class="form-box"><form action="#" method="post" class="form form-damer" id="formulario"><input size="30" style="border:1px solid #ccc" class="custom-search-box" name="w" id="wq" type="text" value="" placeholder="Escriba aquí la palabra" autocomplete="off" autocapitalize="off"/><input style="margin-left:5px" alt="Buscar" type="image" class="icon icon--xsmall icon-grey" src="/themes/custom/front/src/assets/images/lupa.svg" name="submit"></form></div>
+<div class="addtext"><a style="" href="javascript:addText('á','damer');">á</a><a style="" href="javascript:addText('é','damer');">é</a><a style="" href="javascript:addText('í','damer');">í</a><a style="" href="javascript:addText('ó','damer');">ó</a><a style="" href="javascript:addText('ú','damer');">ú</a><a style="" href="javascript:addText('ü','damer');">ü</a><a style="" href="javascript:addText('ñ','damer');">ñ</a></div>
+</div>
+
+<div class="bloque-txt" id="resultados">
+<entry xmlns="http://www.w3.org/1999/xhtml" header="cajeta" key="cajeta" id="nhD9gfjoex0AB1k47sN">
+<table class="da4"><tr><td colspan="5" class="da2"><span class="da8">cajeta.</span></td></tr><tr><td> </td><td colspan="4" class="da2"><span class="da3">I.</span> <span class="da1">(Del</span> <span class="da1">nahua</span> <i><span class="da1">caxitl,</span></i> <span class="da1">escudilla).</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">1.</span></td><td valign="top" colspan="2">f. <i><span class="da5">Mx</span></i><span class="da5">, </span><i><span class="da5">Gu</span></i><span class="da5">, </span><i><span class="da5">Cu</span></i><span class="da5">, </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">PR</span></i><span class="da5">, </span><i><span class="da5">Pe</span></i><span class="da5">;</span><i><span class="da5"> Ec,</span></i><span class="da5"> obsol;</span><i><span class="da5"> Ho</span></i><span class="da5">, pop. Caja en que se ponen o venden dulces, jalea o turr&#xF3;n de diversas formas, seg&#xFA;n el molde que se use.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">2.</span></td><td valign="top" colspan="2"><i><span class="da5">Mx</span></i><span class="da5">, </span><i><span class="da5">Gu</span></i><span class="da5">, </span><i><span class="da5">Pa</span></i><span class="da5">, </span><i><span class="da5">Pe</span></i><span class="da5">;</span><i><span class="da5"> Ho</span></i><span class="da5">, pop. Dulce de leche, </span><i><span class="da0">generalmente de cabra</span></i><span class="da5">, quemada con az&#xFA;car, y </span><span class="da0">de consistencia similar al turr&#xF3;n.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">3.</span></td><td valign="top" colspan="2"><i><span class="da5">Pe.</span></i><span class="da5"> Pastel peque&#xF1;o de harina de ma&#xED;z horneado y relleno </span><i><span class="da0">generalmente de </span></i><i><span class="da9">manjar blanco</span></i><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">4.</span></td><td valign="top" colspan="2"><i><span class="da5">Ec.</span></i><span class="da5"> obsol. Dulce de leche o manjar.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">5.</span></td><td valign="top" colspan="2"><i><span class="da5">Ni</span></i><span class="da5">, </span><i><span class="da5">CR.</span></i><span class="da5"> Dulce similar al turr&#xF3;n, elaborado con </span><a href='panela'>panela</a><span class="da5">, dulce de leche o leche en polvo; puede a&#xF1;ad&#xED;rsele alg&#xFA;n fruto seco rallado, </span><i><span class="da0">especialmente </span></i><i><span class="da9">coco</span></i><i><span class="da5">.</span></i></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">6.</span></td><td valign="top" colspan="2"><i><span class="da5">PR.</span></i><span class="da5"> meton. Dulce que contiene la cajeta.</span></td></tr><tr><td> </td><td class="da7"><span class="da3">II.</span></td><td class="da7"><span class="da3">1.</span></td><td colspan="2" class="da6">f. <i><span class="da5">Ar</span></i><span class="da5">, </span><i><span class="da5">Ur.</span></i><span class="da5"> Vulva. vulg.</span></td></tr><tr><td> </td><td class="da7"><span class="da3">III.</span></td><td class="da7"><span class="da3">1.</span></td><td colspan="2" class="da6">f. <i><span class="da5">Ve:O.</span></i><span class="da5"> Caja peque&#xF1;a, </span><i><span class="da5">generalmente con forma de cono truncado, hecha de cuerno de res o de otros materiales</span></i><span class="da5">, </span><span class="da0">utilizada para guardar el </span><span class="da9">chim&#xF3;</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">2.</span></td><td valign="top" colspan="2"><i><span class="da5">Cu.</span></i><span class="da5"> Caja para el tabaco.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">3.</span></td><td valign="top" colspan="2"><i><span class="da5">Pa.</span></i><span class="da5"> Caja de cart&#xF3;n mediana o peque&#xF1;a </span><span class="da0">para transportar, guardar o envolver cualquier objeto</span><span class="da5">. pop + cult.</span></td></tr><tr><td> </td><td class="da7"><span class="da3">IV.</span></td><td class="da7"><span class="da3">1.</span></td><td colspan="2" class="da6">f. <i><span class="da5">Ar.</span></i><span class="da5"> Buena suerte. vulg.</span></td></tr><tr><td> </td><td class="da7"><span class="da3">V.</span></td><td class="da7"><span class="da3">1.</span></td><td colspan="2" class="da6">f. <i><span class="da5">Ec.</span></i><span class="da5"> Mand&#xED;bula, </span><i><span class="da0">especialmente la de los prognatos</span></i><span class="da5">. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td class="da7"><span class="da3">VI.</span></td><td class="da7"><span class="da3">1.</span></td><td colspan="2" class="da6">f. <i><span class="da5">Cu.</span></i><span class="da5"> Vaina de semillas del algarrobo. rur.</span></td></tr><tr><td> </td><td class="da7"><span class="da3">VII.</span></td><td class="da7"><span class="da3">1.</span></td><td colspan="2" class="da6">f. <i><span class="da5">RD.</span></i><span class="da5"> Molestia, impertinencia.</span></td></tr><tr><td> </td><td colspan="4" class="da2"><span class="da3">VIII.</span> <span class="da1">(De la sigla </span><i><span class="da1">KGB</span></i><span class="da1">, polic&#xED;a secreta de la antigua Uni&#xF3;n Sovi&#xE9;tica).</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">1.</span></td><td valign="top" colspan="2">f. <i><span class="da5">Ho.</span></i><span class="da5"> Polic&#xED;a secreta de la antigua Uni&#xF3;n Sovi&#xE9;tica. cult ^ fest.</span></td></tr><tr><td> </td><td class="da7"><span class="da3">&#x25A1;</span></td><td> </td><td> </td><td> </td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">a. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> de Celaya.</span><span class="da5"> loc. sust. </span><i><span class="da5">Mx.</span></i><span class="da5"> Conciencia exagerada de la propia val&#xED;a, complejo de superioridad.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">b. &#x1C1; </span></td><td colspan="2"><span class="da3">de </span><span class="da0">~</span><span class="da3">.</span><span class="da5"> loc. adj. </span><i><span class="da5">RD.</span></i> <i><span class="da5">Referido a objeto</span></i><span class="da5">, nuevo, sin estrenar.</span></td></tr><tr><td> </td><td class="da7"><span class="da3">&#x25B6;</span></td><td class="da6" colspan="3"><span class="da3">chupar </span><span class="da0">~</span><span class="da5">;</span><span class="da3"> dar </span><span class="da0">~</span><span class="da5">;</span><span class="da3"> tener </span><span class="da0">~</span><span class="da3">, cuchillo y guaro</span><span class="da5">.</span></td></tr></table>
+</entry>
+<p class="o"><center><i><span class="d7">Diccionario de americanismos © 2010<br/>Asociación de Academias de la Lengua Española © Todos los derechos reservados</span></i></center></p><div class="compartir"><a title="Compartir en Facebook" class="resp-sharing-button__link" href="https://facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fcajeta" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--facebook resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M18.77 7.46H14.5v-1.9c0-.9.6-1.1 1-1.1h3V.5h-4.33C10.24.5 9.5 3.44 9.5 5.32v2.15h-3v4h3v12h5v-12h3.85l.42-4z"/></svg></div></div></a>
+<a title="Compartir en Twitter" class="resp-sharing-button__link" href="https://twitter.com/intent/tweet/?text=cajeta - Diccionario de americanismos&url=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fcajeta" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--twitter resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M23.44 4.83c-.8.37-1.5.38-2.22.02.93-.56.98-.96 1.32-2.02-.88.52-1.86.9-2.9 1.1-.82-.88-2-1.43-3.3-1.43-2.5 0-4.55 2.04-4.55 4.54 0 .36.03.7.1 1.04-3.77-.2-7.12-2-9.36-4.75-.4.67-.6 1.45-.6 2.3 0 1.56.8 2.95 2 3.77-.74-.03-1.44-.23-2.05-.57v.06c0 2.2 1.56 4.03 3.64 4.44-.67.2-1.37.2-2.06.08.58 1.8 2.26 3.12 4.25 3.16C5.78 18.1 3.37 18.74 1 18.46c2 1.3 4.4 2.04 6.97 2.04 8.35 0 12.92-6.92 12.92-12.93 0-.2 0-.4-.02-.6.9-.63 1.96-1.22 2.56-2.14z"/></svg></div></div></a>
+<a title="Compartir por correo electrónico" class="resp-sharing-button__link" href="/cdn-cgi/l/email-protection#3f004c4a5d555a5c4b025c5e555a4b5e1f121f7b565c5c5650515e4d56501f5b5a1f5e525a4d565c5e51564c52504c195d505b4602574b4b4f4c051010484848115e4c5e535a11504d58105b5e525a4d105c5e555a4b5e1a0f7e1a0f7e76111f0e111f72471f131f784a1f131f7c4a1f131f6d7b1f131f6f6d1f131f6f5a1f041f7a5c131f505d4c5053041f77501f131f4f504f111f7c5e555e1f5a511f4e4a5a1f4c5a1f4f50515a511f501f495a515b5a511f5b4a535c5a4c131f555e535a5e1f501f4b4a4d4dfc8c511f5b5a1f5b56495a4d4c5e4c1f59504d525e4c131f4c5a58fc85511f5a531f5250535b5a1f4e4a5a1f4c5a1f4a4c5a11" target="_self" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--email resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M22 4H2C.9 4 0 4.9 0 6v12c0 1.1.9 2 2 2h20c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zM7.25 14.43l-3.5 2c-.08.05-.17.07-.25.07-.17 0-.34-.1-.43-.25-.14-.24-.06-.55.18-.68l3.5-2c.24-.14.55-.06.68.18.14.24.06.55-.18.68zm4.75.07c-.1 0-.2-.03-.27-.08l-8.5-5.5c-.23-.15-.3-.46-.15-.7.15-.22.46-.3.7-.14L12 13.4l8.23-5.32c.23-.15.54-.08.7.15.14.23.07.54-.16.7l-8.5 5.5c-.08.04-.17.07-.27.07zm8.93 1.75c-.1.16-.26.25-.43.25-.08 0-.17-.02-.25-.07l-3.5-2c-.24-.13-.32-.44-.18-.68s.44-.32.68-.18l3.5 2c.24.13.32.44.18.68z"/></svg></div></div></a>
+<a title="Compartir en WhatsApp" class="resp-sharing-button__link" href="whatsapp://send?text=cajeta - Diccionario de americanismos%20https%3A%2F%2Fwww.asale.org%2Fdamer%2Fcajeta" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--whatsapp resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20.1 3.9C17.9 1.7 15 .5 12 .5 5.8.5.7 5.6.7 11.9c0 2 .5 3.9 1.5 5.6L.6 23.4l6-1.6c1.6.9 3.5 1.3 5.4 1.3 6.3 0 11.4-5.1 11.4-11.4-.1-2.8-1.2-5.7-3.3-7.8zM12 21.4c-1.7 0-3.3-.5-4.8-1.3l-.4-.2-3.5 1 1-3.4L4 17c-1-1.5-1.4-3.2-1.4-5.1 0-5.2 4.2-9.4 9.4-9.4 2.5 0 4.9 1 6.7 2.8 1.8 1.8 2.8 4.2 2.8 6.7-.1 5.2-4.3 9.4-9.5 9.4zm5.1-7.1c-.3-.1-1.7-.9-1.9-1-.3-.1-.5-.1-.7.1-.2.3-.8 1-.9 1.1-.2.2-.3.2-.6.1s-1.2-.5-2.3-1.4c-.9-.8-1.4-1.7-1.6-2-.2-.3 0-.5.1-.6s.3-.3.4-.5c.2-.1.3-.3.4-.5.1-.2 0-.4 0-.5C10 9 9.3 7.6 9 7c-.1-.4-.4-.3-.5-.3h-.6s-.4.1-.7.3c-.3.3-1 1-1 2.4s1 2.8 1.1 3c.1.2 2 3.1 4.9 4.3.7.3 1.2.5 1.6.6.7.2 1.3.2 1.8.1.6-.1 1.7-.7 1.9-1.3.2-.7.2-1.2.2-1.3-.1-.3-.3-.4-.6-.5z"/></svg></div></div></a>
+<a title="Compartir en Telegram" class="resp-sharing-button__link" href="https://telegram.me/share/url?text=cajeta - Diccionario de americanismos&url=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fcajeta" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--telegram resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M.707 8.475C.275 8.64 0 9.508 0 9.508s.284.867.718 1.03l5.09 1.897 1.986 6.38a1.102 1.102 0 0 0 1.75.527l2.96-2.41a.405.405 0 0 1 .494-.013l5.34 3.87a1.1 1.1 0 0 0 1.046.135 1.1 1.1 0 0 0 .682-.803l3.91-18.795A1.102 1.102 0 0 0 22.5.075L.706 8.475z"/></svg></div></div></a>
+<a title="Compartir en Pinterest" class="resp-sharing-button__link" href="https://pinterest.com/pin/create/button/?url=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fcajeta&media=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fcajeta&description=I. 1. Mx , Gu , Cu , RD , PR , Pe ; Ec, obsol; Ho , pop. Caja en que se ponen o venden dulces, jalea o turrón de diversas formas, según el molde que se use." target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--pinterest resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.14.5C5.86.5 2.7 5 2.7 8.75c0 2.27.86 4.3 2.7 5.05.3.12.57 0 .66-.33l.27-1.06c.1-.32.06-.44-.2-.73-.52-.62-.86-1.44-.86-2.6 0-3.33 2.5-6.32 6.5-6.32 3.55 0 5.5 2.17 5.5 5.07 0 3.8-1.7 7.02-4.2 7.02-1.37 0-2.4-1.14-2.07-2.54.4-1.68 1.16-3.48 1.16-4.7 0-1.07-.58-1.98-1.78-1.98-1.4 0-2.55 1.47-2.55 3.42 0 1.25.43 2.1.43 2.1l-1.7 7.2c-.5 2.13-.08 4.75-.04 5 .02.17.22.2.3.1.14-.18 1.82-2.26 2.4-4.33.16-.58.93-3.63.93-3.63.45.88 1.8 1.65 3.22 1.65 4.25 0 7.13-3.87 7.13-9.05C20.5 4.15 17.18.5 12.14.5z"/></svg></div></div></a>
+<a title="Compartir en LinkedIn" class="resp-sharing-button__link" href="https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fcajeta&title=cajeta - Diccionario de americanismos&summary=I. 1. Mx , Gu , Cu , RD , PR , Pe ; Ec, obsol; Ho , pop. Caja en que se ponen o venden dulces, jalea o turrón de diversas formas, según el molde que se use.&source=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fcajeta" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--linkedin resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
+<svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M6.5 21.5h-5v-13h5v13zM4 6.5C2.5 6.5 1.5 5.3 1.5 4s1-2.4 2.5-2.4c1.6 0 2.5 1 2.6 2.5 0 1.4-1 2.5-2.6 2.5zm11.5 6c-1 0-2 1-2 2v7h-5v-13h5V10s1.6-1.5 4-1.5c3 0 5 2.2 5 6.3v6.7h-5v-7c0-1-1-2-2-2z"/></svg></div></div></a></div></div>
+</div>
+<div data-nosnippet class="col-xs-12 col-md-4 bloque-txt">
+<h2 class="ayuda">Más información</h2>
+<div class="view-node-navigation"><ul class="menu"><li class="leaf d0"><a target="_blank" title="Prólogo de la obra" class="tooltip" href="https://www.asale.org/sites/default/files/Prologo_Diccionario_de_americanismos.pdf">Prólogo</a> de la obra</li><li class="leaf d0"><a target="_blank" title="Preliminares (abreviaturas) de la obra" class="tooltip" href="https://www.asale.org/sites/default/files/Abreviaturas_del_DA.pdf">Preliminares</a> (abreviaturas) de la obra</li></ul></div>
+
+    
+<div><h2 class="ayuda">Rueda de palabras</h2>
+<div>
+<ul class='rueda'><li><a href='/damer/cajchadera'>cajchadera</a></li><li><a href='/damer/cajchazo'>cajchazo</a></li><li><a href='/damer/cajcheadura'>cajcheadura</a></li><li><a href='/damer/cajchear'>cajchear</a></li><li><a href='/damer/cajchi'>cajchi</a></li><li><a href='/damer/cajera'>cajera</a></li><li><a href='/damer/cajero'>cajero</a></li><li><b>cajeta</b></li><li><a href='/damer/cajetazo'>cajetazo</a></li><li><a href='/damer/cajete'>cajete</a></li><li><a href='/damer/cajeteado'>cajeteado</a></li><li><a href='/damer/cajetear'>cajetear</a></li><li><a href='/damer/cajetearse'>cajetearse</a></li><li><a href='/damer/cajetera'>cajetera</a></li><li><a href='/damer/cajetero'>cajetero</a></li></ul></div>
+</div>
+</div>
+</div>
+</div>
+<div data-nosnippet class="clearfix" id="main">
+    <div data-nosnippet class="cog--mq mq-main">
+
+            <section class="section section--secondary o-section--large">
+  <div data-nosnippet class="container">
+
+    <h2 class="section__title" data-aos="fade-up" data-aos-offset="50" data-aos-delay="200" data-aos-duration="1000">
+      <span class="divider__title"></span>
+      También le interesará
+    </h2>
+
+    <div data-nosnippet class="row">
+
+      <div data-nosnippet class="col-xs-12 col-md-6 col-lg-3"
+           data-aos="fade-up"
+           data-aos-offset="150"
+           data-aos-delay="400"
+           data-aos-duration="800">
+          <div data-nosnippet class="views-element-container">
+<div data-nosnippet class="js-view-dom-id-02a2d65813f4ad19486655be44ae3d013bf874ea18cdb029038d81b8f502454b vista">
+    
+    
+    
+
+    
+    
+    
+
+    
+
+  
+
+<div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/noticia/la-asociacion-de-academias-de-la-lengua-espanola-celebra-su-70o-aniversario-bajo-la">70 AÑOS DE ASALE</a></p>
+
+      <div data-nosnippet class="block-news__img img">
+      <a target="_self" title="Actos de celebración del 70 aniversario" href="/noticia/la-asociacion-de-academias-de-la-lengua-espanola-celebra-su-70o-aniversario-bajo-la">
+        <img class="b-lazy"
+             src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+             data-src="/sites/default/files/styles/tambien_interesa/public/2021-12/70%20anos%20asale.jpg?itok=kU8Y2JlT"
+             alt="Los reyes de España han presidido en el salón de actos de la RAE el solemne acto institucional conmemorativo del septuagésimo aniversario de la Asociación de Academias de la Lengua Española (ASALE). Foto: RAE. " />
+      </a>
+    </div>
+  
+      <span class="news__date">
+      
+    </span>
+  
+  <p class="block-news__title u-text-brandsecondary">
+    <a target="_self" title="Actos de celebración del 70 aniversario" href="/noticia/la-asociacion-de-academias-de-la-lengua-espanola-celebra-su-70o-aniversario-bajo-la">
+      Actos de celebración del 70 aniversario
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+
+  
+
+<div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/obras-academicas/clasicos-asale">Clásicos ASALE</a></p>
+
+      <div data-nosnippet class="block-news__img img">
+      <a target="_self" title="Conozca los títulos de toda la colección" href="/obras-academicas/clasicos-asale">
+        <img class="b-lazy"
+             src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+             data-src="/sites/default/files/styles/tambien_interesa/public/imagenes/articulos/Foto_La_Voz_de_Galicia_1_1.png?itok=nG30FJfh"
+             alt="Nuevos títulos de la colección Clásicos ASALE  " />
+      </a>
+    </div>
+  
+      <span class="news__date">
+      
+    </span>
+  
+  <p class="block-news__title u-text-brandsecondary">
+    <a target="_self" title="Conozca los títulos de toda la colección" href="/obras-academicas/clasicos-asale">
+      Conozca los títulos de toda la colección
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+
+        
+
+    
+    
+
+    
+</div>
+</div>
+
+      </div>
+
+
+      <div data-nosnippet class="col-xs-12 col-md-6 col-lg-8 u-border-left"
+           data-aos="fade-up"
+           data-aos-offset="150"
+           data-aos-delay="400"
+           data-aos-duration="800">
+          <div data-nosnippet class="views-element-container">
+<div data-nosnippet class="js-view-dom-id-b5df2b64bbf6d0641e267cd9ab9d13eb19064524d5085d5ec1cde593ffb30d5b vista">
+    
+    
+    
+
+    
+    
+    
+
+    
+<div data-nosnippet class="row">
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/lexicografia" hreflang="es">Lexicografía</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Cuarta convocatoria del Programa ASALE de becas de formación y colaboración destinado a las academias de la Asociación de Academias de la Lengua Española (ASALE) " href="/noticia/cuarta-convocatoria-del-programa-asale-de-becas-de-formacion-y-colaboracion-destinado-las">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/imagenes/articulos/centro_de_estudios_RAE_serrano.jpg?h=c9f93661&amp;itok=zfPMAJv-"
+               alt="Sede de la Escuela de Lexicografía (Serrano, 187-189) en Madrid (foto: RAE)">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2025-05-27T12:00:00Z">27 de Mayo de 2025</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Cuarta convocatoria del Programa ASALE de becas de formación y colaboración destinado a las academias de la Asociación de Academias de la Lengua Española (ASALE) " href="/noticia/cuarta-convocatoria-del-programa-asale-de-becas-de-formacion-y-colaboracion-destinado-las">
+      <span>Cuarta convocatoria del Programa ASALE de becas de formación y colaboración destinado a las academias de la Asociación de Academias de la Lengua Española (ASALE) </span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/academicos" hreflang="es">Académicos</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Carlos Martini, nuevo miembro de número de la Academia Paraguaya de la Lengua Española" href="/noticia/carlos-martini-nuevo-miembro-de-numero-de-la-academia-paraguaya-de-la-lengua-espanola">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/2021-11/Sede_APARLE.jpg?h=9e499333&amp;itok=BhYtrdjy"
+               alt="Sede de la Academia Paraguaya de la Lengua Española">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2025-01-13T12:00:00Z">13 de Enero de 2025</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Carlos Martini, nuevo miembro de número de la Academia Paraguaya de la Lengua Española" href="/noticia/carlos-martini-nuevo-miembro-de-numero-de-la-academia-paraguaya-de-la-lengua-espanola">
+      <span>Carlos Martini, nuevo miembro de número de la Academia Paraguaya de la Lengua Española</span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/obituarios" hreflang="es">Obituarios</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Fallece Tarsicio Herrera Zapién, miembro de la Academia Mexicana de la Lengua" href="/noticia/fallece-tarsicio-herrera-zapien-miembro-de-la-academia-mexicana-de-la-lengua">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/imagenes/academicos/Tarsicio_Herrera_Sapien_www.cultura.gob_.mx_.jpg?h=c9f93661&amp;itok=XE1zuFdY"
+               alt="Tarsicio Herrera Zapién, miembro de número de la Academia Mexicana de la Lengua. Foto: Secretaría de Cultura.">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2026-02-05T12:00:00Z">5 de Febrero de 2026</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Fallece Tarsicio Herrera Zapién, miembro de la Academia Mexicana de la Lengua" href="/noticia/fallece-tarsicio-herrera-zapien-miembro-de-la-academia-mexicana-de-la-lengua">
+      <span>Fallece Tarsicio Herrera Zapién, miembro de la Academia Mexicana de la Lengua</span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/academicos" hreflang="es">Académicos</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Félix Julio Alfonso López ingresa en la Academia Cubana de la Lengua" href="/noticia/felix-julio-alfonso-lopez-ingresa-en-la-academia-cubana-de-la-lengua">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/2026-02/F%C3%A9lix%20Julio%20Alfonso%20L%C3%B3pez_0.jpg?h=8b436e18&amp;itok=6lYXMiAr"
+               alt="Félix Julio Alfonso López">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2026-02-04T12:00:00Z">4 de Febrero de 2026</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Félix Julio Alfonso López ingresa en la Academia Cubana de la Lengua" href="/noticia/felix-julio-alfonso-lopez-ingresa-en-la-academia-cubana-de-la-lengua">
+      <span>Félix Julio Alfonso López ingresa en la Academia Cubana de la Lengua</span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+  </div>
+
+        
+
+    
+    
+
+    
+</div>
+</div>
+
+      </div>
+
+
+    </div>
+  </div>
+</section>
+
+            <section class="section o-section--medium">
+
+  <div data-nosnippet class="container">
+    <div data-nosnippet class="u-text-center">
+
+      <div data-nosnippet class="btn btn-up" data-aos="fade-up" data-aos-offset="50" data-aos-delay="200" data-aos-duration="1000">
+        <a href="#main" class="ancla">
+          <svg class="icon icon--small icon-black">
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-up"></use>
+          </svg>
+          <p class="btn__text">Arriba</p>
+        </a>
+      </div>
+
+    </div>
+  </div>
+
+</section>
+
+    </div>
+  </div>
+
+  
+  <footer id="footer" class="footer">
+  <div data-nosnippet class="container">
+    <div data-nosnippet class="pre-footer">
+
+      <p class="footer-privacidad">
+        REAL ACADEMIA ESPAÑOLA. Finalidades: Recopilación de información lingüística para la investigación, desarrollo, proyección y buen uso de la lengua española en el ámbito de la IA (proyecto LEIA). Derechos: tiene derecho a acceder, rectificar y suprimir sus datos, así como a otros derechos como se explica en la información adicional y detallada que se puede consultar en nuestra 
+        <span class="privacidad-link privacidad-link--inverse"><a href="/politica-de-privacidad-y-proteccion-de-los-datos-personales" target="_blank">política de privacidad</a>.</span>
+      </p>
+
+    </div>
+
+    <div data-nosnippet class="sub-footer">
+      <div data-nosnippet class="sub-footer__social">
+        <a title="Síganos en X" href="https://x.com/RAEinforma" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en X</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#twitter"></use>
+    </svg>
+</a>
+<a title="Síganos en Facebook"  href="https://www.facebook.com/RAE/" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en Facebook</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#facebook"></use>
+    </svg>
+</a>
+<a title="Visite nuestro Instagram" href="https://www.instagram.com/laraeinforma/" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Visite nuestro Instagram</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#instagram"></use>
+    </svg>
+</a>
+<a title="Síganos en TikTok" href="https://www.tiktok.com/@rae.informa" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en TikTok</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#tiktok"></use>
+    </svg>
+</a>
+<a title="Visite nuestras galerías" href="https://www.flickr.com/photos/raeinforma" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Visite nuestras galerías</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#flicker"></use>
+    </svg>
+</a>
+<a title="Síganos en Youtube" href="https://www.youtube.com/user/RAEInforma" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en Youtube</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#youtube"></use>
+    </svg>
+</a>
+
+<a title="Escuche nuestras listas de música" href="https://open.spotify.com/user/u0gt78txho8qqa5m843kkvxy2" rel="noopener" target="_blank">
+  <svg class="icon icon--medium">
+    <title>Escuche nuestras listas de música</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#spoty"></use>
+  </svg>
+</a>
+
+<a title="Síganos en Souncloud" href="https://soundcloud.com/real-academia-espanola" rel="noopener" target="_blank">
+  <svg class="icon icon--medium">
+    <title>Síganos en Soundcloud</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#soundcloud"></use>
+  </svg>
+</a>
+
+<a title="Contacte con nosotros" href="/contacto-rae">
+  <svg class="icon icon--medium">
+    <title>Contacte con nosotros</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#email"></use>
+  </svg>
+</a>
+
+      </div>
+
+      <div data-nosnippet class="sub-footer__link">
+        <a title="Visitar Fundación pro-RAE" href="/fundacion">Fundación pro-Rae</a>
+        <a title="Visitar web ASALE" href="https://www.asale.org/" rel="noopener" target="_blank">Asale</a>
+      </div>
+
+
+      <p class="footer__text">
+        Felipe IV, 5 - 28014 Madrid - Teléfono:
+        <a title="Teléfono contacto" href="tel:34914201478">+34 91 420 14 78</a>
+        <span class="ml-1 d-inline-block">
+          © Real Academia Española, 2019
+        </span>
+      </p>
+
+      
+
+<nav role="navigation" aria-labelledby="block-piedepagina" id="block-piedepagina" class="block block-menu navigation block-system-menublock menu--footer">
+      
+        
+
+                        <ul class="footer-list">
+                            <li class="footer-list__item">
+                <a href="https://rae.whistlelink.com" target="_blank">Canal del informante</a>
+                            </li>
+                </ul>
+    
+
+
+  </nav>
+
+    </div>
+
+  </div>
+</footer>
+
+<div data-nosnippet class="search-full-container">
+  <span class="menu-buttom__close">
+  <svg class="icon icon--xsmall icon-black">
+    <title>cerrar</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#close"></use>
+  </svg>
+</span>
+  <div data-nosnippet class="container">
+
+    <div data-nosnippet class="header__logo">
+      <div data-nosnippet class="img">
+        <a href="/" title="Inicio - Real Academia Española" rel="home" class="site-logo">
+          <svg class="icon icon-logo">
+            <title>Logo RAE</title>
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#logo-rae"></use>
+          </svg>
+        </a>
+      </div>
+    </div>
+    <div data-nosnippet class="row justify-content-center">
+      <div data-nosnippet class="col-12 col-md-8">
+        <h2 class="search__title">Buscador general de la RAE</h2>
+
+        <form class="search-block-form" data-drupal-selector="search-block-form" action="/search/node" method="get" id="search-block-form" accept-charset="UTF-8">
+  <div data-nosnippet class="js-form-item form-item js-form-type-search form-type-search js-form-item-keys form-item-keys form-no-label">
+      <label for="edit-keys" class="visually-hidden">Search</label>
+        <input title="Escriba lo que quiere buscar." placeholder="Buscar en la web" data-drupal-selector="edit-keys" type="search" id="edit-keys" name="keys" value="" size="15" maxlength="128" class="form-search" />
+
+        </div>
+<div data-nosnippet data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions"><input alt="Buscar en la web" data-drupal-selector="edit-submit" type="image" id="edit-submit" name="op" src="/themes/custom/front/src/assets/images/lupa.svg" class="image-button js-form-submit form-submit" />
+</div>
+
+</form>
+
+      </div>
+    </div>
+  </div>
+</div>
+
+<div data-nosnippet class="dle-full-container">
+  <span class="menu-buttom__close">
+  <svg class="icon icon--xsmall icon-black">
+    <title>cerrar</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#close"></use>
+  </svg>
+</span>
+  <div data-nosnippet class="contenedor-full">
+
+    <div data-nosnippet class="container">
+      <div data-nosnippet class="row justify-content-between">
+
+        <div data-nosnippet class="col-xs-12 col-lg-7">
+          <div data-nosnippet class="diccionarios-container">
+            <h2 class="diccionarios-container__title">Diccionarios</h2>
+            <form class="diccionarios-form" data-drupal-selector="diccionarios-form" action="/" method="post" id="diccionarios-form" accept-charset="UTF-8">
+  <div data-nosnippet id="edit-diccionario"><div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dle" type="radio" id="edit-diccionario-dle" name="diccionario" value="dle" checked="checked" class="form-radio" />
+
+        <label for="edit-diccionario-dle" class="option">Diccionario de la lengua española</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dpd" type="radio" id="edit-diccionario-dpd" name="diccionario" value="dpd" class="form-radio" />
+
+        <label for="edit-diccionario-dpd" class="option">Diccionario panhispánico de dudas</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dpej" type="radio" id="edit-diccionario-dpej" name="diccionario" value="dpej" class="form-radio" />
+
+        <label for="edit-diccionario-dpej" class="option">Diccionario panhispánico del español jurídico</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dhle" type="radio" id="edit-diccionario-dhle" name="diccionario" value="dhle" class="form-radio" />
+
+        <label for="edit-diccionario-dhle" class="option">Diccionario histórico de la lengua española</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-damer" type="radio" id="edit-diccionario-damer" name="diccionario" value="damer" class="form-radio" />
+
+        <label for="edit-diccionario-damer" class="option">Diccionario de americanismos</label>
+      </div>
+</div>
+<fieldset data-drupal-selector="edit-caja" id="edit-caja" class="form-item js-form-wrapper form-wrapper">
+      <legend>
+    <span class="fieldset-legend"></span>
+  </legend>
+  <div data-nosnippet class="fieldset-wrapper">
+            <div data-nosnippet class="js-form-item form-item js-form-type-textfield form-type-textfield js-form-item-termino form-item-termino form-no-label">
+        <input aria-label="Término" data-drupal-selector="edit-termino" type="text" id="edit-termino" name="termino" value="" size="60" maxlength="128" placeholder="Escriba el término" class="form-text required" required="required" aria-required="true" />
+
+        </div>
+<input class="icon--small image-button js-form-submit form-submit" alt="Escriba el término" data-drupal-selector="edit-submit" type="image" id="edit-submit--2" name="op" src="/themes/custom/front/src/assets/images/lupa.svg" />
+
+          </div>
+</fieldset>
+<div data-nosnippet class="logo"><div data-nosnippet data-drupal-selector="edit-lacaixa-modal" data-drupal-states="{&quot;visible&quot;:[{&quot;:input[name=\u0022diccionario\u0022]&quot;:{&quot;value&quot;:&quot;dle&quot;}}]}" id="edit-lacaixa-modal" class="js-form-wrapper form-wrapper"><a title="Fundación “la Caixa”" rel="noopener" target="_blank" href="https://fundacionlacaixa.org/es/home"><img src="/themes/custom/front/src/assets/svg/logo-fundacion-caixa.svg" alt="Logo Obra social “la Caixa”"></a></div>
+</div><input autocomplete="off" data-drupal-selector="form-xia40oqp-xumj65oafjg5thtpkciat38yywr-l468i4" type="hidden" name="form_build_id" value="form-XIA40Oqp-xUMJ65oafjg5thtPkCIat38YyWR-l468I4" />
+<input data-drupal-selector="edit-diccionarios-form" type="hidden" name="form_id" value="diccionarios_form" />
+<div data-nosnippet data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions--3"></div>
+
+</form>
+
+          </div>
+        </div>
+        <div data-nosnippet class="col-xs-12 col-lg-4">
+          <div data-nosnippet class="dudas-container">
+            <h2 class="dudas-container__title">Dudas rápidas</h2>
+            <form class="dudas-form-modal" data-drupal-selector="dudas-form-modal" action="/" method="post" id="dudas-form-modal" accept-charset="UTF-8">
+  <fieldset data-drupal-selector="edit-caja-dudas-modal" id="edit-caja-dudas-modal" class="form-item js-form-wrapper form-wrapper">
+      <legend>
+    <span class="fieldset-legend"></span>
+  </legend>
+  <div data-nosnippet class="fieldset-wrapper">
+            <div data-nosnippet class="js-form-item form-item js-form-type-textfield form-type-textfield js-form-item-duda-modal form-item-duda-modal form-no-label">
+        <input aria-label="Término" data-drupal-selector="edit-duda-modal" type="text" id="edit-duda-modal" name="duda_modal" value="" size="60" maxlength="128" placeholder="Escriba las palabras clave" class="form-text required" required="required" aria-required="true" />
+
+        </div>
+<input class="icon--small image-button js-form-submit form-submit" alt="Buscar duda" data-drupal-selector="edit-submit-modal" type="image" id="edit-submit-modal" name="op" src="/themes/custom/front/src/assets/images/lupa.svg" />
+
+          </div>
+</fieldset>
+<input autocomplete="off" data-drupal-selector="form-cvfp2zsxkvagunug3dkccupvudyupyammxp4ka-jrzq" type="hidden" name="form_build_id" value="form-cvFP2zsxkVagunUg3dKcCupVUDYUPYAMMXp4kA-JRZQ" />
+<input data-drupal-selector="edit-dudas-form-modal" type="hidden" name="form_id" value="dudas_form_modal" />
+<div data-nosnippet data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions--5"></div>
+
+</form>
+
+          </div>
+        </div>
+      </div>
+
+      <div data-nosnippet class="recursos-container">
+        <h2 class="title__medium text-center mb-7">
+          Otros Recursos
+          <svg class="icon icon--xsmall icon-black">
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#plus"></use>
+          </svg>
+          <svg class="icon icon--xsmall icon-black hidden">
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#menos"></use>
+          </svg>
+        </h2>
+        <div data-nosnippet class="lista-recursos-container">
+          
+
+
+    
+          <ul class="lista-recursos" >
+    
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Diccionarios</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://dle.rae.es/">Diccionario de la lengua española</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/dpd/">Diccionario panhispánico de dudas</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://dpej.rae.es/">Diccionario panhispánico del español jurídico</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="/dhle">Diccionario histórico de la lengua española</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.asale.org/damer/">Diccionario de americanismos</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/diccionario-estudiante/" title="Diccionario del estudiante">Diccionario del estudiante</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/tdhle/" title="Tesoro de diccionarios históricos de la lengua">Tesoro de diccionarios históricos de la lengua</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/DA.html">Diccionario de autoridades</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://apps.rae.es/ntlle/SrvltGUISalirNtlle">Nuevo tesoro lexicográfico</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/ntllet/SrvltGUILoginNtlletPub">Mapa de diccionarios</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/DH1936.html">Diccionario histórico (1933-1936)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/DH.html">Diccionario histórico (1960-1996)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/drae2001/">Diccionario de la lengua española (2001)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/desen/">Diccionario esencial (2006)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/formulario-de-la-unidad-interactiva-del-diccionario" title="Envíe las propuestas y sugerencias externas relacionadas con el «Diccionario de la lengua española»">Unidad Interactiva del Diccionario (UNIDRAE)</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Banco de datos</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/corpes/">CORPES XXI</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/CNDHE/">CDH</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://corpus.rae.es/creanet.html">CREA</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/crea-anotado/" title="CREA anotado">CREA anotado</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://corpus.rae.es/cordenet.html">CORDE</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/fichero.html">Fichero general</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.asale.org/corpus-asale/">Corpus ASALE</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Gramática</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://aplica.rae.es/grweb/cgi-bin/buscar.cgi">Nueva gramática de la lengua española</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/gtg/">Glosario de términos gramaticales</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/sites/default/files/Gramatica_RAE_1771_reducida.pdf">Primera gramática</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/gram%C3%A1tica-b%C3%A1sica/" title="Nueva gramática básica de la lengua española">Nueva gramática básica de la lengua española</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Ortografía</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://aplica.rae.es/orweb/cgi-bin/buscar.cgi">Ortografía 2010</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="/sites/default/files/Ortografia_RAE_1741_reducida.pdf">Primera ortografía</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/ortograf%C3%ADa-b%C3%A1sica/" title="Ortografía básica de la lengua española">Ortografía básica de la lengua española</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Biblioteca</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca/biblioteca-academica">Biblioteca académica</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca/legado-antonio-rodriguez-monino-y-maria-brey">Legado Rodríguez-Moñino</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca/legado-damaso-alonso">Legado Dámaso Alonso</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca-digital" title="Biblioteca Digital">Biblioteca Digital</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Archivo</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://archivo.rae.es/">Fondo institucional</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://archivo.rae.es/index.php/coleccion-de-autografos-de-pedro-antonio-de-alarcon">Colección P. A. de Alarcón</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://archivo.rae.es/zorrilla/">Zorrilla</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/manuscritos-para-la-segunda-edicion-del-diccionario-de-autoridades">2.ª edición del «Diccionario de autoridades»</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://archivo.rae.es/fichero-de-hilo">Fichero de hilo</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Boletines</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://revistas.rae.es/bilrae/">BILRAE</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://revistas.rae.es/brae">BRAE</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span title="Recursos académicos de apoyo para el lenguaje claro">Lenguaje claro</span>
+          </div>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Enclave</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://enclavedeciencia.rae.es/inicio">Enclave de Ciencia</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Enlaces externos</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://asines.org/">Atlas sintáctico del español</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/dhecan.html">Diccionario Histórico del Español de Canarias</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/CORLEXIN.html">Corpus Léxico de Inventarios</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://lla.unileon.es/" title="Léxico leonés actual">Léxico leonés actual</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+    
+  </ul>
+  
+
+
+        </div>
+      </div>
+
+
+    </div>
+
+  </div>
+</div>
+
+</div>
+
+  </div>
+
+      
+
+    </div>
+
+    
+
+
+  <script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script src="/sites/default/files/js/js_7hSOT9HVKxMvGlrclR4TDcqOUtAR-0e88Vkq_P_PROE.js"></script>\n<script src="/damer/js/20210406.js"></script>
+<!--[if IE]>
+<style>
+#deletex{ display:none;}
+</style>
+<![endif]-->
+</body>
+<script>
+window.cat='EXTERNO';window.acc='www.asale.org/damer/cajeta';window.eti='';
+</script>
+</html>

--- a/tests/cogs/damer_sample_htmls/country.html
+++ b/tests/cogs/damer_sample_htmls/country.html
@@ -1,0 +1,1337 @@
+<!DOCTYPE html>
+<html lang="es">
+<head><noscript><style>form.antibot * :not(.antibot-message) { display: none !important; }</style></noscript>
+<link rel="preload" href="/sites/default/files/css/css_dEGQ1dTiz0ecdWEF6e88CxjAquRE_grpqzD40Q6WYlc.css" as="style">
+<link rel="preload" href="/sites/default/files/css/css_MKU0IOMhjZnRGgSeMxmlSpwNVcEMZOFPTb3EZkC-BVI.css" as="style">
+<link rel="preload" href="/sites/default/files/js/js_b-ar_0H4iDIMUsW8GfJsDFfYU0G5JxN3w3EHDaWDWFw.js" as="script">
+<link rel="preload" href="/damer/css/20201019.css" as="style">
+<link rel="preload" href="/damer/js/20210406.js" as="script">
+<link rel="preload" href="/themes/custom/front/assets/fonts/lato/lato-bold-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/lato/lato-regular-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/merriweather/merriweather-black-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/merriweather/merriweather-light-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/merriweather/merriweather-regular-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="canonical" href="https://www.asale.org/damer/country"/>
+<title>country | Diccionario de americanismos | ASALE</title>
+<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="Definición de «country» según el Diccionario de americanismos: ■ a. ǁ club. m. EU , Ni , PR , Ve , Ec , Ch , Py . Club campestre de actividades deportivas, ."/>
+<meta name="keywords" content="country, definición de country, significado de country, ASALE, RAE"/>
+<meta name="author" content="ASALE"/>
+<meta name="robots" content="index,follow"/>
+<meta name="rating" content="safe for kids"/>
+<meta name="rights" content="Asociación de Academias de la Lengua Española © Todos los derechos reservados"/>
+<meta name="author" content="ASALE">
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:site" content="\@ASALEinforma"/>
+<meta name="twitter:url" content="https://www.asale.org/damer/country"/>
+<meta name="twitter:title" content="country | Diccionario de americanismos"/>
+<meta name="twitter:description" content="Definición de «country» según el Diccionario de americanismos: ■ a. ǁ club. m. EU , Ni , PR , Ve , Ec , Ch , Py . Club campestre de actividades deportivas, ."/>
+<meta name="twitter:image" content="/damer/img/logo-asale.png"/>
+<meta name="twitter:image:alt" content="«Diccionario de americanismos»"/>
+<meta property="article:author" content="https://es-es.facebook.com/asale"/>
+<meta property="og:title" content="country | Diccionario de americanismos"/>
+<meta property="og:type" content="website"/>
+<meta property="og:site_name" content="«Diccionario de americanismos»"/>
+<meta property="og:url" content="https://www.asale.org/damer/country"/>
+<meta property="og:description" content="Definición de «country» según el Diccionario de americanismos: ■ a. ǁ club. m. EU , Ni , PR , Ve , Ec , Ch , Py . Club campestre de actividades deportivas, ."/>
+<meta property="og:locale" content="es"/>
+<meta property="og:image" content="/damer/img/logo-asale.png"/>
+<meta property="og:image:type" content="image/png"/>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<link rel="shortcut icon" href="/themes/custom/front/favicon.ico" />
+<link rel="mask-icon" href="/themes/custom/front/src/assets/images/favicons/safari-pinned-tab.svg" />
+<link rel="icon" sizes="16x16" href="/themes/custom/front/src/assets/images/favicons/favicon-16x16.png" />
+<link rel="icon" sizes="32x32" href="/themes/custom/front/src/assets/images/favicons/favicon-32x32.png" />
+<link rel="apple-touch-icon" sizes="180x180" href="/themes/custom/front/src/assets/images/favicons/apple-touch-icon.png" />
+<link rel="apple-touch-icon-precomposed" sizes="180x180" href="/themes/custom/front/src/assets/images/favicons/apple-touch-icon.png" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=2, minimum-scale=1, user-scalable=yes" />
+<!--[if lt IE 9]><script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+<script type="application/ld+json">
+[{"@context": "http://schema.org/"},{"@type": ["DefinedTermSet","Book"],"@id": "https://www.asale.org/damer","name": "Diccionario de americanismos RAE - ASALE","image": "https://www.asale.org/damer/img/logo-asale.png","description": "Versión electrónica del «Diccionario de americanismos»."},{"@type": "DefinedTerm","@id": "https://www.asale.org/damer/country","name": "country","description": "Definición de «country» según el Diccionario de americanismos: ■ a. ǁ club. m. EU , Ni , PR , Ve , Ec , Ch , Py . Club campestre de actividades deportivas, .","inDefinedTermSet": "https://www.asale.org/damer"}]
+</script><link rel="stylesheet" media="all" href="/sites/default/files/css/css_dEGQ1dTiz0ecdWEF6e88CxjAquRE_grpqzD40Q6WYlc.css"/>
+<link rel="stylesheet" media="all" href="/sites/default/files/css/css_MKU0IOMhjZnRGgSeMxmlSpwNVcEMZOFPTb3EZkC-BVI.css"/>
+<script>window.a2a_config=window.a2a_config||{};a2a_config.callbacks=[];a2a_config.overlays=[];a2a_config.templates={};a2a_config.static_server= "https://www.asale.org/sites/default/files/addtoany/menu/oafg07ee";a2a_config.icon_color = "transparent,#000";</script>
+
+<link rel="stylesheet" media="all" href="/damer/css/20201019.css"/>
+</head>
+<body class="path--node body-sidebars-none alias--noticia-primera-reunion-plenaria-virtual-de-directores-y-presidentes-de-las-academias-de-la-lengua nodetype--noticia logged-out" data-aos-easing="ease" data-aos-duration="400" data-aos-delay="0">
+<div role="main">
+<div class="dialog-off-canvas-main-canvas" data-off-canvas-main-canvas="">
+<div class="page-standard" id="pg__c">
+
+<header id="header" class="header">
+
+  <div class="header__logo">
+    <div class="img">
+                <a href="/" title="Inicio - ASALE" rel="home" class="site-logo">
+            <img src="/themes/custom/asale/assets/images/logo-asale.png" alt="Logo ASALE"/>
+          </a>
+          </div>
+  </div>
+
+  <div class="header-menu-search">
+
+    <nav class="header-menu">
+
+      <div class="main-menu-container">
+        <span class="menu-buttom__close">
+  <svg class="icon icon--xsmall icon-black">
+    <title>cerrar</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#close"></use>
+  </svg>
+</span>
+        
+
+<nav role="navigation" aria-labelledby="block-navegacionprincipalasale" id="block-navegacionprincipalasale" class="block block-menu navigation block-system-menublock menu--main-asale">
+      
+        
+
+
+              <ul class="menu-list main">
+              <li class="menu-list__item" >
+
+                  <div class="parent-item">
+            <a href="/la-asociacion" data-drupal-link-system-path="node/29051">La Asociación</a>
+            <span class="menu-collapse">
+              <svg class="icon icon--xsmall icon-black">
+                <title>Abrir submenu</title>
+                <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-bottom"></use>
+              </svg>
+            </span>
+          </div>
+        
+
+                                <ul>
+              <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/bienvenida" data-drupal-link-system-path="node/31480">Bienvenida</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/presentacion" data-drupal-link-system-path="node/31494">Presentación</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/comision-permanente" data-drupal-link-system-path="node/29478">Comisión Permanente</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/politica-panhispanica" data-drupal-link-system-path="node/31648">Política panhispánica</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/actividad-institucional" data-drupal-link-system-path="node/31515">Actividad institucional</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/biblioteca-de-la-asale" data-drupal-link-system-path="node/31634">Biblioteca de la ASALE</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/conmemoraciones" data-drupal-link-system-path="node/31641">Conmemoraciones</a>
+        
+
+              </li>
+      </ul>
+    
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/academias" data-drupal-link-system-path="academias">Academias</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <div class="parent-item">
+            <a href="/obras" data-drupal-link-system-path="node/29030">Obras</a>
+            <span class="menu-collapse">
+              <svg class="icon icon--xsmall icon-black">
+                <title>Abrir submenu</title>
+                <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-bottom"></use>
+              </svg>
+            </span>
+          </div>
+        
+
+                                <ul>
+              <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/diccionarios" data-drupal-link-system-path="taxonomy/term/100">Diccionarios</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/gramatica" data-drupal-link-system-path="taxonomy/term/101">Gramática</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/ortografia" data-drupal-link-system-path="taxonomy/term/102">Ortografía</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/ediciones-conmemorativas" data-drupal-link-system-path="taxonomy/term/103">Ediciones conmemorativas</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/clasicos-asale" data-drupal-link-system-path="taxonomy/term/337">Clásicos ASALE</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/otras-obras" data-drupal-link-system-path="taxonomy/term/330">Otras obras</a>
+        
+
+              </li>
+      </ul>
+    
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/corpus" data-drupal-link-system-path="node/29037">Corpus</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <div class="parent-item">
+            <a href="/escuela-de-lexicografia" data-drupal-link-system-path="node/29044">Escuela de Lexicografía</a>
+            <span class="menu-collapse">
+              <svg class="icon icon--xsmall icon-black">
+                <title>Abrir submenu</title>
+                <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-bottom"></use>
+              </svg>
+            </span>
+          </div>
+        
+
+                                <ul>
+              <li class="menu-list__item" >
+
+                  <a href="/escuela-de-lexicografia/la-elh" data-drupal-link-system-path="node/32131">La ELH</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/escuela-de-lexicografia/master-de-lexicografia-hispanica-y-correccion-linguistica" data-drupal-link-system-path="node/86216">Máster</a>
+        
+
+              </li>
+      </ul>
+    
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/publicaciones" data-drupal-link-system-path="node/28988">Publicaciones</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/noticias" data-drupal-link-system-path="noticias">Noticias</a>
+        
+
+              </li>
+      </ul>
+    
+
+
+  </nav>
+      </div>
+
+      <ul class="search-block">
+        <li class="menu-list__item link-dle">
+          <svg class="icon icon--tiny icon-white">
+            <title>Recursos</title>
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#diccionarios"></use>
+          </svg>
+          <span class="menu-list__text">Recursos</span>
+        </li>
+        <li class="menu-list__item link-search">
+          <svg class="icon icon--xsmall icon-white">
+            <title>Buscador</title>
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#lupa"></use>
+          </svg>
+        </li>
+        <li class="menu-list__item link-menu">
+          <svg class="icon icon--small icon-white">
+            <title>Menu</title>
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#menu"></use>
+          </svg>
+        </li>
+      </ul>
+
+    </nav>
+  </div>
+</header>
+<div class="container">
+<div class="row">
+<div class="col-xs-12 col-md-8" style="border-right:1px solid #ccc">  
+<div style="margin: 20px 0 10px 0;font-size:2em"><a href="/damer/">Diccionario de americanismos</a></div>
+<div class="form-box-wrapper">
+<div class="form-box"><form action="#" method="post" class="form form-damer" id="formulario"><input size="30" style="border:1px solid #ccc" class="custom-search-box" name="w" id="wq" type="text" value="" placeholder="Escriba aquí la palabra" autocomplete="off" autocapitalize="off"/><input style="margin-left:5px" alt="Buscar" type="image" class="icon icon--xsmall icon-grey" src="/themes/custom/front/src/assets/images/lupa.svg" name="submit"></form></div>
+<div class="addtext"><a style="" href="javascript:addText('á','damer');">á</a><a style="" href="javascript:addText('é','damer');">é</a><a style="" href="javascript:addText('í','damer');">í</a><a style="" href="javascript:addText('ó','damer');">ó</a><a style="" href="javascript:addText('ú','damer');">ú</a><a style="" href="javascript:addText('ü','damer');">ü</a><a style="" href="javascript:addText('ñ','damer');">ñ</a></div>
+</div>
+
+<div class="bloque-txt" id="resultados">
+<entry xmlns="http://www.w3.org/1999/xhtml" header="_country_" key="country" id="XjGHZ6qZIx0AEKa8ZHu">
+<table class="da4"><tr><td colspan="5" class="da2"><i><span class="da8">country.</span></i> <span class="da1">(Voz inglesa</span><i><span class="da1">, campo</span></i><span class="da1">).</span></td></tr><tr><td> </td><td class="da7"><span class="da3">&#x25A0;</span></td><td> </td><td> </td><td> </td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">a. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> club.</span><span class="da5"> m. </span><i><span class="da5">EU</span></i><span class="da5">, </span><i><span class="da5">Ni</span></i><span class="da5">, </span><i><span class="da5">PR</span></i><span class="da5">, </span><i><span class="da5">Ve</span></i><span class="da5">, </span><i><span class="da5">Ec</span></i><span class="da5">, </span><i><span class="da5">Ch</span></i><span class="da5">, </span><i><span class="da5">Py</span></i><span class="da5">. Club campestre de actividades deportivas, </span><i><span class="da0">especialmente de golf</span></i><span class="da5">.</span></td></tr></table>
+</entry>
+<p class="o"><center><i><span class="d7">Diccionario de americanismos © 2010<br/>Asociación de Academias de la Lengua Española © Todos los derechos reservados</span></i></center></p><div class="compartir"><a title="Compartir en Facebook" class="resp-sharing-button__link" href="https://facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fcountry" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--facebook resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M18.77 7.46H14.5v-1.9c0-.9.6-1.1 1-1.1h3V.5h-4.33C10.24.5 9.5 3.44 9.5 5.32v2.15h-3v4h3v12h5v-12h3.85l.42-4z"/></svg></div></div></a>
+<a title="Compartir en Twitter" class="resp-sharing-button__link" href="https://twitter.com/intent/tweet/?text=country - Diccionario de americanismos&url=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fcountry" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--twitter resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M23.44 4.83c-.8.37-1.5.38-2.22.02.93-.56.98-.96 1.32-2.02-.88.52-1.86.9-2.9 1.1-.82-.88-2-1.43-3.3-1.43-2.5 0-4.55 2.04-4.55 4.54 0 .36.03.7.1 1.04-3.77-.2-7.12-2-9.36-4.75-.4.67-.6 1.45-.6 2.3 0 1.56.8 2.95 2 3.77-.74-.03-1.44-.23-2.05-.57v.06c0 2.2 1.56 4.03 3.64 4.44-.67.2-1.37.2-2.06.08.58 1.8 2.26 3.12 4.25 3.16C5.78 18.1 3.37 18.74 1 18.46c2 1.3 4.4 2.04 6.97 2.04 8.35 0 12.92-6.92 12.92-12.93 0-.2 0-.4-.02-.6.9-.63 1.96-1.22 2.56-2.14z"/></svg></div></div></a>
+<a title="Compartir por correo electrónico" class="resp-sharing-button__link" href="/cdn-cgi/l/email-protection#457a3630272f20263178262a302b31373c656865012c26262c2a2b24372c2a65212065242820372c26242b2c36282a3663272a213c782d313135367f6a6a3232326b24362429206b2a37226a21242820376a262a302b31373c6075046075040120232c2b2c262c86f62b6521206587ee262a302b31373c87fe6536202286ff2b65202965012c26262c2a2b24372c2a65212065242820372c26242b2c36282a367f65a7d3e565246b6582c465262930276b65286b6500106569650b2c656965151765696513206569650026656965062d656965153c656b650629302765262428352036313720652120652426312c332c2124212036652120352a37312c33243669656b" target="_self" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--email resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M22 4H2C.9 4 0 4.9 0 6v12c0 1.1.9 2 2 2h20c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zM7.25 14.43l-3.5 2c-.08.05-.17.07-.25.07-.17 0-.34-.1-.43-.25-.14-.24-.06-.55.18-.68l3.5-2c.24-.14.55-.06.68.18.14.24.06.55-.18.68zm4.75.07c-.1 0-.2-.03-.27-.08l-8.5-5.5c-.23-.15-.3-.46-.15-.7.15-.22.46-.3.7-.14L12 13.4l8.23-5.32c.23-.15.54-.08.7.15.14.23.07.54-.16.7l-8.5 5.5c-.08.04-.17.07-.27.07zm8.93 1.75c-.1.16-.26.25-.43.25-.08 0-.17-.02-.25-.07l-3.5-2c-.24-.13-.32-.44-.18-.68s.44-.32.68-.18l3.5 2c.24.13.32.44.18.68z"/></svg></div></div></a>
+<a title="Compartir en WhatsApp" class="resp-sharing-button__link" href="whatsapp://send?text=country - Diccionario de americanismos%20https%3A%2F%2Fwww.asale.org%2Fdamer%2Fcountry" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--whatsapp resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20.1 3.9C17.9 1.7 15 .5 12 .5 5.8.5.7 5.6.7 11.9c0 2 .5 3.9 1.5 5.6L.6 23.4l6-1.6c1.6.9 3.5 1.3 5.4 1.3 6.3 0 11.4-5.1 11.4-11.4-.1-2.8-1.2-5.7-3.3-7.8zM12 21.4c-1.7 0-3.3-.5-4.8-1.3l-.4-.2-3.5 1 1-3.4L4 17c-1-1.5-1.4-3.2-1.4-5.1 0-5.2 4.2-9.4 9.4-9.4 2.5 0 4.9 1 6.7 2.8 1.8 1.8 2.8 4.2 2.8 6.7-.1 5.2-4.3 9.4-9.5 9.4zm5.1-7.1c-.3-.1-1.7-.9-1.9-1-.3-.1-.5-.1-.7.1-.2.3-.8 1-.9 1.1-.2.2-.3.2-.6.1s-1.2-.5-2.3-1.4c-.9-.8-1.4-1.7-1.6-2-.2-.3 0-.5.1-.6s.3-.3.4-.5c.2-.1.3-.3.4-.5.1-.2 0-.4 0-.5C10 9 9.3 7.6 9 7c-.1-.4-.4-.3-.5-.3h-.6s-.4.1-.7.3c-.3.3-1 1-1 2.4s1 2.8 1.1 3c.1.2 2 3.1 4.9 4.3.7.3 1.2.5 1.6.6.7.2 1.3.2 1.8.1.6-.1 1.7-.7 1.9-1.3.2-.7.2-1.2.2-1.3-.1-.3-.3-.4-.6-.5z"/></svg></div></div></a>
+<a title="Compartir en Telegram" class="resp-sharing-button__link" href="https://telegram.me/share/url?text=country - Diccionario de americanismos&url=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fcountry" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--telegram resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M.707 8.475C.275 8.64 0 9.508 0 9.508s.284.867.718 1.03l5.09 1.897 1.986 6.38a1.102 1.102 0 0 0 1.75.527l2.96-2.41a.405.405 0 0 1 .494-.013l5.34 3.87a1.1 1.1 0 0 0 1.046.135 1.1 1.1 0 0 0 .682-.803l3.91-18.795A1.102 1.102 0 0 0 22.5.075L.706 8.475z"/></svg></div></div></a>
+<a title="Compartir en Pinterest" class="resp-sharing-button__link" href="https://pinterest.com/pin/create/button/?url=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fcountry&media=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fcountry&description=Definición de «country» según el Diccionario de americanismos: ■ a. ǁ club. m. EU , Ni , PR , Ve , Ec , Ch , Py . Club campestre de actividades deportivas, ." target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--pinterest resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.14.5C5.86.5 2.7 5 2.7 8.75c0 2.27.86 4.3 2.7 5.05.3.12.57 0 .66-.33l.27-1.06c.1-.32.06-.44-.2-.73-.52-.62-.86-1.44-.86-2.6 0-3.33 2.5-6.32 6.5-6.32 3.55 0 5.5 2.17 5.5 5.07 0 3.8-1.7 7.02-4.2 7.02-1.37 0-2.4-1.14-2.07-2.54.4-1.68 1.16-3.48 1.16-4.7 0-1.07-.58-1.98-1.78-1.98-1.4 0-2.55 1.47-2.55 3.42 0 1.25.43 2.1.43 2.1l-1.7 7.2c-.5 2.13-.08 4.75-.04 5 .02.17.22.2.3.1.14-.18 1.82-2.26 2.4-4.33.16-.58.93-3.63.93-3.63.45.88 1.8 1.65 3.22 1.65 4.25 0 7.13-3.87 7.13-9.05C20.5 4.15 17.18.5 12.14.5z"/></svg></div></div></a>
+<a title="Compartir en LinkedIn" class="resp-sharing-button__link" href="https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fcountry&title=country - Diccionario de americanismos&summary=Definición de «country» según el Diccionario de americanismos: ■ a. ǁ club. m. EU , Ni , PR , Ve , Ec , Ch , Py . Club campestre de actividades deportivas, .&source=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fcountry" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--linkedin resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
+<svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M6.5 21.5h-5v-13h5v13zM4 6.5C2.5 6.5 1.5 5.3 1.5 4s1-2.4 2.5-2.4c1.6 0 2.5 1 2.6 2.5 0 1.4-1 2.5-2.6 2.5zm11.5 6c-1 0-2 1-2 2v7h-5v-13h5V10s1.6-1.5 4-1.5c3 0 5 2.2 5 6.3v6.7h-5v-7c0-1-1-2-2-2z"/></svg></div></div></a></div></div>
+</div>
+<div data-nosnippet class="col-xs-12 col-md-4 bloque-txt">
+<h2 class="ayuda">Más información</h2>
+<div class="view-node-navigation"><ul class="menu"><li class="leaf d0"><a target="_blank" title="Prólogo de la obra" class="tooltip" href="https://www.asale.org/sites/default/files/Prologo_Diccionario_de_americanismos.pdf">Prólogo</a> de la obra</li><li class="leaf d0"><a target="_blank" title="Preliminares (abreviaturas) de la obra" class="tooltip" href="https://www.asale.org/sites/default/files/Abreviaturas_del_DA.pdf">Preliminares</a> (abreviaturas) de la obra</li></ul></div>
+
+    
+<div><h2 class="ayuda">Rueda de palabras</h2>
+<div>
+<ul class='rueda'><li><a href='/damer/cotudera'>cotudera</a></li><li><a href='/damer/cotudo'>cotudo</a></li><li><a href='/damer/cotufa'>cotufa</a></li><li><a href='/damer/cotuta'>cotuta</a></li><li><a href='/damer/cotuza'>cotuza</a></li><li><a href='/damer/couch'>couch</a></li><li><a href='/damer/counter'>counter</a></li><li><b>country</b></li><li><a href='/damer/coure'>coure</a></li><li><a href='/damer/courier'>courier</a></li><li><a href='/damer/courrier'>courrier</a></li><li><a href='/damer/course'>course</a></li><li><a href='/damer/court'>court</a></li><li><a href='/damer/cousín'>cousín</a></li><li><a href='/damer/coutí'>coutí</a></li></ul></div>
+</div>
+</div>
+</div>
+</div>
+<div data-nosnippet class="clearfix" id="main">
+    <div data-nosnippet class="cog--mq mq-main">
+
+            <section class="section section--secondary o-section--large">
+  <div data-nosnippet class="container">
+
+    <h2 class="section__title" data-aos="fade-up" data-aos-offset="50" data-aos-delay="200" data-aos-duration="1000">
+      <span class="divider__title"></span>
+      También le interesará
+    </h2>
+
+    <div data-nosnippet class="row">
+
+      <div data-nosnippet class="col-xs-12 col-md-6 col-lg-3"
+           data-aos="fade-up"
+           data-aos-offset="150"
+           data-aos-delay="400"
+           data-aos-duration="800">
+          <div data-nosnippet class="views-element-container">
+<div data-nosnippet class="js-view-dom-id-0391552d3fa15790aafe3bd0ac55b6fdf7bc88ddbf1a2dd2d553dea270c40711 vista">
+    
+    
+    
+
+    
+    
+    
+
+    
+
+  
+
+<div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/noticia/la-asociacion-de-academias-de-la-lengua-espanola-celebra-su-70o-aniversario-bajo-la">70 AÑOS DE ASALE</a></p>
+
+      <div data-nosnippet class="block-news__img img">
+      <a target="_self" title="Actos de celebración del 70 aniversario" href="/noticia/la-asociacion-de-academias-de-la-lengua-espanola-celebra-su-70o-aniversario-bajo-la">
+        <img class="b-lazy"
+             src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+             data-src="/sites/default/files/styles/tambien_interesa/public/2021-12/70%20anos%20asale.jpg?itok=kU8Y2JlT"
+             alt="Los reyes de España han presidido en el salón de actos de la RAE el solemne acto institucional conmemorativo del septuagésimo aniversario de la Asociación de Academias de la Lengua Española (ASALE). Foto: RAE. " />
+      </a>
+    </div>
+  
+      <span class="news__date">
+      
+    </span>
+  
+  <p class="block-news__title u-text-brandsecondary">
+    <a target="_self" title="Actos de celebración del 70 aniversario" href="/noticia/la-asociacion-de-academias-de-la-lengua-espanola-celebra-su-70o-aniversario-bajo-la">
+      Actos de celebración del 70 aniversario
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+
+  
+
+<div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/obras-academicas/clasicos-asale">Clásicos ASALE</a></p>
+
+      <div data-nosnippet class="block-news__img img">
+      <a target="_self" title="Conozca los títulos de toda la colección" href="/obras-academicas/clasicos-asale">
+        <img class="b-lazy"
+             src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+             data-src="/sites/default/files/styles/tambien_interesa/public/imagenes/articulos/Foto_La_Voz_de_Galicia_1_1.png?itok=nG30FJfh"
+             alt="Nuevos títulos de la colección Clásicos ASALE  " />
+      </a>
+    </div>
+  
+      <span class="news__date">
+      
+    </span>
+  
+  <p class="block-news__title u-text-brandsecondary">
+    <a target="_self" title="Conozca los títulos de toda la colección" href="/obras-academicas/clasicos-asale">
+      Conozca los títulos de toda la colección
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+
+        
+
+    
+    
+
+    
+</div>
+</div>
+
+      </div>
+
+
+      <div data-nosnippet class="col-xs-12 col-md-6 col-lg-8 u-border-left"
+           data-aos="fade-up"
+           data-aos-offset="150"
+           data-aos-delay="400"
+           data-aos-duration="800">
+          <div data-nosnippet class="views-element-container">
+<div data-nosnippet class="js-view-dom-id-eea275bff3b26d1be7461bb644f0af8d0a9cc96a4a09e56e06ae58881aa39130 vista">
+    
+    
+    
+
+    
+    
+    
+
+    
+<div data-nosnippet class="row">
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/lexicografia" hreflang="es">Lexicografía</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Cuarta convocatoria del Programa ASALE de becas de formación y colaboración destinado a las academias de la Asociación de Academias de la Lengua Española (ASALE) " href="/noticia/cuarta-convocatoria-del-programa-asale-de-becas-de-formacion-y-colaboracion-destinado-las">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/imagenes/articulos/centro_de_estudios_RAE_serrano.jpg?h=c9f93661&amp;itok=zfPMAJv-"
+               alt="Sede de la Escuela de Lexicografía (Serrano, 187-189) en Madrid (foto: RAE)">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2025-05-27T12:00:00Z">27 de Mayo de 2025</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Cuarta convocatoria del Programa ASALE de becas de formación y colaboración destinado a las academias de la Asociación de Academias de la Lengua Española (ASALE) " href="/noticia/cuarta-convocatoria-del-programa-asale-de-becas-de-formacion-y-colaboracion-destinado-las">
+      <span>Cuarta convocatoria del Programa ASALE de becas de formación y colaboración destinado a las academias de la Asociación de Academias de la Lengua Española (ASALE) </span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/academicos" hreflang="es">Académicos</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Carlos Martini, nuevo miembro de número de la Academia Paraguaya de la Lengua Española" href="/noticia/carlos-martini-nuevo-miembro-de-numero-de-la-academia-paraguaya-de-la-lengua-espanola">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/2021-11/Sede_APARLE.jpg?h=9e499333&amp;itok=BhYtrdjy"
+               alt="Sede de la Academia Paraguaya de la Lengua Española">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2025-01-13T12:00:00Z">13 de Enero de 2025</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Carlos Martini, nuevo miembro de número de la Academia Paraguaya de la Lengua Española" href="/noticia/carlos-martini-nuevo-miembro-de-numero-de-la-academia-paraguaya-de-la-lengua-espanola">
+      <span>Carlos Martini, nuevo miembro de número de la Academia Paraguaya de la Lengua Española</span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/obituarios" hreflang="es">Obituarios</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Fallece Eduardo Buenaventura Badía Serra, exdirector de la Academia Salvadoreña de la Lengua" href="/noticia/fallece-eduardo-buenaventura-badia-serra-exdirector-de-la-academia-salvadorena-de-la-lengua">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/2021-08/Eduardo%20Buenaventura%20Bad%C3%ADa%20Serra.png?h=d5d04e3b&amp;itok=Hb3DbG3C"
+               alt="Eduardo Buenaventura Badía Serra, miembro de la Academia Salvadoreña de la Lengua">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2026-01-22T12:00:00Z">22 de Enero de 2026</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Fallece Eduardo Buenaventura Badía Serra, exdirector de la Academia Salvadoreña de la Lengua" href="/noticia/fallece-eduardo-buenaventura-badia-serra-exdirector-de-la-academia-salvadorena-de-la-lengua">
+      <span>Fallece Eduardo Buenaventura Badía Serra, exdirector de la Academia Salvadoreña de la Lengua</span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/academicos" hreflang="es">Académicos</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Carlos Arcos Cabrera ingresa en la Academia Ecuatoriana de la Lengua " href="/noticia/carlos-arcos-cabrera-ingresa-en-la-academia-ecuatoriana-de-la-lengua">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/2026-01/Carlos-Arcos-Cabrera.jpg?h=a73d1241&amp;itok=ZgtiefpF"
+               alt="Página institucional de la Academia Ecuatoriana de la Lengua">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2026-01-22T12:00:00Z">22 de Enero de 2026</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Carlos Arcos Cabrera ingresa en la Academia Ecuatoriana de la Lengua " href="/noticia/carlos-arcos-cabrera-ingresa-en-la-academia-ecuatoriana-de-la-lengua">
+      <span>Carlos Arcos Cabrera ingresa en la Academia Ecuatoriana de la Lengua </span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+  </div>
+
+        
+
+    
+    
+
+    
+</div>
+</div>
+
+      </div>
+
+
+    </div>
+  </div>
+</section>
+
+            <section class="section o-section--medium">
+
+  <div data-nosnippet class="container">
+    <div data-nosnippet class="u-text-center">
+
+      <div data-nosnippet class="btn btn-up" data-aos="fade-up" data-aos-offset="50" data-aos-delay="200" data-aos-duration="1000">
+        <a href="#main" class="ancla">
+          <svg class="icon icon--small icon-black">
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-up"></use>
+          </svg>
+          <p class="btn__text">Arriba</p>
+        </a>
+      </div>
+
+    </div>
+  </div>
+
+</section>
+
+    </div>
+  </div>
+
+  
+  <footer id="footer" class="footer">
+  <div data-nosnippet class="footerlist">
+    <div data-nosnippet class="views-element-container">
+<div data-nosnippet  class="js-view-dom-id-c5ccb65b5ca143e4fafbffe2293a471f13f9272e4a826139553873e46adb9a43 container">
+  
+  
+  
+
+  
+  
+  
+
+  <div data-nosnippet class="item-list">
+  
+  <ul>
+
+          <li><a href="/academias/real-academia-espanola" hreflang="es">Real Academia Española</a></li>
+          <li><a href="/academias/academia-colombiana-de-la-lengua" hreflang="es">Academia Colombiana de la Lengua </a></li>
+          <li><a href="/academias/academia-ecuatoriana-de-la-lengua" hreflang="es">Academia Ecuatoriana de la Lengua</a></li>
+          <li><a href="/academias/academia-mexicana-de-la-lengua" hreflang="es">Academia Mexicana de la Lengua</a></li>
+          <li><a href="/academias/academia-salvadorena-de-la-lengua" hreflang="es">Academia Salvadoreña de la Lengua</a></li>
+          <li><a href="/academias/academia-venezolana-de-la-lengua" hreflang="es">Academia Venezolana de la Lengua</a></li>
+          <li><a href="/academias/academia-chilena-de-la-lengua" hreflang="es">Academia Chilena de la Lengua</a></li>
+          <li><a href="/academias/academia-peruana-de-la-lengua" hreflang="es">Academia Peruana de la Lengua</a></li>
+          <li><a href="/academias/academia-guatemalteca-de-la-lengua" hreflang="es">Academia Guatemalteca de la Lengua</a></li>
+          <li><a href="/academias/academia-costarricense-de-la-lengua" hreflang="es">Academia Costarricense de la Lengua</a></li>
+          <li><a href="/academias/academia-filipina-de-la-lengua-espanola" hreflang="es">Academia Filipina de la Lengua Española</a></li>
+          <li><a href="/academias/academia-panamena-de-la-lengua" hreflang="es">Academia Panameña de la Lengua</a></li>
+          <li><a href="/academias/academia-cubana-de-la-lengua" hreflang="es">Academia Cubana de la Lengua</a></li>
+          <li><a href="/academias/academia-paraguaya-de-la-lengua-espanola" hreflang="es">Academia Paraguaya de la Lengua Española</a></li>
+          <li><a href="/academias/academia-boliviana-de-la-lengua" hreflang="es">Academia Boliviana de la Lengua</a></li>
+          <li><a href="/academias/academia-dominicana-de-la-lengua" hreflang="es">Academia Dominicana de la Lengua</a></li>
+          <li><a href="/academias/academia-nicaraguense-de-la-lengua" hreflang="es">Academia Nicaragüense de la Lengua</a></li>
+          <li><a href="/academias/academia-argentina-de-letras" hreflang="es">Academia Argentina de Letras</a></li>
+          <li><a href="/academias/academia-nacional-de-letras-uruguay" hreflang="es">Academia Nacional de Letras (Uruguay)</a></li>
+          <li><a href="/academias/academia-hondurena-de-la-lengua" hreflang="es">Academia Hondureña de la Lengua</a></li>
+          <li><a href="/academias/academia-puertorriquena-de-la-lengua-espanola" hreflang="es">Academia Puertorriqueña de la Lengua Española</a></li>
+          <li><a href="/academias/academia-norteamericana-de-la-lengua-espanola" hreflang="es">Academia Norteamericana de la Lengua Española</a></li>
+          <li><a href="/academias/academia-ecuatoguineana-de-la-lengua-espanola" hreflang="es">Academia Ecuatoguineana de la Lengua Española</a></li>
+    
+  </ul>
+
+</div>
+
+    
+
+  
+  
+
+
+  
+</div>
+</div>
+
+
+  </div>
+
+  <div data-nosnippet class="sub-footer">
+    <div data-nosnippet class="sub-footer__social">
+      <a title="Síganos en X" href="http://www.x.com/ASALEInforma" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en X</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#twitter"></use>
+    </svg>
+</a>
+<a title="Síganos en Facebook"  href="https://facebook.com/ASALE" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en Facebook</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#facebook"></use>
+    </svg>
+</a>
+
+    </div>
+
+    <p>Felipe IV, 4 - 28014 Madrid - <br />Teléfono: +34 91 420 14 78. <br /> © Real Academia Española, 2019</p>
+
+    <div data-nosnippet class="footer-legal pb-6">
+        
+
+<nav role="navigation" aria-labelledby="block-piedepaginaasale" id="block-piedepaginaasale" class="block block-menu navigation block-system-menublock menu--footer-asale">
+      
+        
+
+                        <ul class="footer-list">
+                            <li class="footer-list__item">
+                <a href="/info/asale/aviso-legal" data-drupal-link-system-path="node/29079">Aviso legal</a>
+                            </li>
+                    <li class="footer-list__item">
+                <a href="/info/asale/privacidad" data-drupal-link-system-path="node/29065">Política de privacidad</a>
+                            </li>
+                    <li class="footer-list__item">
+                <a href="/info/asale/cookies" data-drupal-link-system-path="node/29072">Política de cookies</a>
+                            </li>
+                    <li class="footer-list__item">
+                <a href="/info/asale/accesibilidad" data-drupal-link-system-path="node/29086">Accesibilidad</a>
+                            </li>
+                    <li class="footer-list__item">
+                <a href="/contacto/asale" data-drupal-link-system-path="node/28995">Contacto</a>
+                            </li>
+                </ul>
+    
+
+
+  </nav>
+    </div>
+
+    <div data-nosnippet class="d-flex pb-5">
+      <a href="https://www.ciencia.gob.es/" target="_blank" rel="nofollow">
+        <img height="67px" src="/themes/custom/front/assets/images/MCIU_footer.svg"
+             alt="Logo Ministerio de Ciencia e Innovación">
+      </a>
+    </div>
+
+  </div>
+
+
+
+</footer>
+
+<div data-nosnippet class="search-full-container">
+  <span class="menu-buttom__close">
+  <svg class="icon icon--xsmall icon-black">
+    <title>cerrar</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#close"></use>
+  </svg>
+</span>
+  <div data-nosnippet class="container">
+
+    <div data-nosnippet class="header__logo">
+      <div data-nosnippet class="img">
+        <a href="/" title="Inicio - ASALE" rel="home" class="site-logo">
+          <img class="icon-logo" src="/themes/custom/asale/assets/images/logo-asale-color.png" alt="Logo ASALE"/>
+        </a>
+      </div>
+    </div>
+    <div data-nosnippet class="row justify-content-center">
+      <div data-nosnippet class="col-12 col-md-8">
+        <h2 class="search__title">Buscador general ASALE</h2>
+        <form class="search-block-form" data-drupal-selector="search-block-form" action="/search/node" method="get" id="search-block-form" accept-charset="UTF-8">
+  <div data-nosnippet class="js-form-item form-item js-form-type-search form-type-search js-form-item-keys form-item-keys form-no-label">
+      <label for="edit-keys" class="visually-hidden">Search</label>
+        <input title="Escriba lo que quiere buscar." placeholder="Buscar en la web" data-drupal-selector="edit-keys" type="search" id="edit-keys" name="keys" value="" size="15" maxlength="128" class="form-search" />
+
+        </div>
+<div data-nosnippet data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions"><input alt="Buscar en la web" data-drupal-selector="edit-submit" type="image" id="edit-submit" name="op" src="/themes/custom/front/src/assets/images/lupa.svg" class="image-button js-form-submit form-submit" />
+</div>
+
+</form>
+
+      </div>
+    </div>
+  </div>
+</div>
+
+<div data-nosnippet class="dle-full-container">
+  <span class="menu-buttom__close">
+  <svg class="icon icon--xsmall icon-black">
+    <title>cerrar</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#close"></use>
+  </svg>
+</span>
+  <div data-nosnippet class="contenedor-full">
+
+    <div data-nosnippet class="container">
+      <div data-nosnippet class="row justify-content-between">
+
+        <div data-nosnippet class="col-xs-12 col-lg-7">
+          <div data-nosnippet class="diccionarios-container">
+            <h2 class="diccionarios-container__title">Diccionarios</h2>
+            <form class="diccionarios-form" data-drupal-selector="diccionarios-form" action="/" method="post" id="diccionarios-form" accept-charset="UTF-8">
+  <div data-nosnippet id="edit-diccionario"><div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dle" type="radio" id="edit-diccionario-dle" name="diccionario" value="dle" checked="checked" class="form-radio" />
+
+        <label for="edit-diccionario-dle" class="option">Diccionario de la lengua española</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dpd" type="radio" id="edit-diccionario-dpd" name="diccionario" value="dpd" class="form-radio" />
+
+        <label for="edit-diccionario-dpd" class="option">Diccionario panhispánico de dudas</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dpej" type="radio" id="edit-diccionario-dpej" name="diccionario" value="dpej" class="form-radio" />
+
+        <label for="edit-diccionario-dpej" class="option">Diccionario panhispánico del español jurídico</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dhle" type="radio" id="edit-diccionario-dhle" name="diccionario" value="dhle" class="form-radio" />
+
+        <label for="edit-diccionario-dhle" class="option">Diccionario histórico de la lengua española</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-damer" type="radio" id="edit-diccionario-damer" name="diccionario" value="damer" class="form-radio" />
+
+        <label for="edit-diccionario-damer" class="option">Diccionario de americanismos</label>
+      </div>
+</div>
+<fieldset data-drupal-selector="edit-caja" id="edit-caja" class="form-item js-form-wrapper form-wrapper">
+      <legend>
+    <span class="fieldset-legend"></span>
+  </legend>
+  <div data-nosnippet class="fieldset-wrapper">
+            <div data-nosnippet class="js-form-item form-item js-form-type-textfield form-type-textfield js-form-item-termino form-item-termino form-no-label">
+        <input aria-label="Término" data-drupal-selector="edit-termino" type="text" id="edit-termino" name="termino" value="" size="60" maxlength="128" placeholder="Escriba el término" class="form-text required" required="required" aria-required="true" />
+
+        </div>
+<input class="icon--small image-button js-form-submit form-submit" alt="Escriba el término" data-drupal-selector="edit-submit" type="image" id="edit-submit--2" name="op" src="/themes/custom/front/src/assets/images/lupa.svg" />
+
+          </div>
+</fieldset>
+<div data-nosnippet class="logo"><div data-nosnippet data-drupal-selector="edit-lacaixa-modal" data-drupal-states="{&quot;visible&quot;:[{&quot;:input[name=\u0022diccionario\u0022]&quot;:{&quot;value&quot;:&quot;dle&quot;}}]}" id="edit-lacaixa-modal" class="js-form-wrapper form-wrapper"><a title="Fundación “la Caixa”" rel="noopener" target="_blank" href="https://fundacionlacaixa.org/es/home"><img src="/themes/custom/front/src/assets/svg/logo-fundacion-caixa.svg" alt="Logo Obra social “la Caixa”"></a></div>
+</div><input autocomplete="off" data-drupal-selector="form-rcsgydxlh89ylr64f1bfqqyp5bquexp8m0jgt0yqghm" type="hidden" name="form_build_id" value="form-rcSGYDxLH89Ylr64F1bfQQyP5BqUExP8M0JGt0yqGhM" />
+<input data-drupal-selector="edit-diccionarios-form" type="hidden" name="form_id" value="diccionarios_form" />
+<div data-nosnippet data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions--3"></div>
+
+</form>
+
+          </div>
+        </div>
+
+      </div>
+
+      <div data-nosnippet class="recursos-container">
+        <h2 class="title__medium text-center mb-7">
+          Otros Recursos
+          <svg class="icon icon--xsmall icon-black">
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#plus"></use>
+          </svg>
+          <svg class="icon icon--xsmall icon-black hidden">
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#menos"></use>
+          </svg>
+        </h2>
+        <div data-nosnippet class="lista-recursos-container">
+          
+
+
+    
+          <ul class="lista-recursos" >
+    
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Diccionarios</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://dle.rae.es/">Diccionario de la lengua española</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/dpd/">Diccionario panhispánico de dudas</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://dpej.rae.es/">Diccionario panhispánico del español jurídico</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="/dhle">Diccionario histórico de la lengua española</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.asale.org/damer/">Diccionario de americanismos</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/diccionario-estudiante/" title="Diccionario del estudiante">Diccionario del estudiante</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/tdhle/" title="Tesoro de diccionarios históricos de la lengua">Tesoro de diccionarios históricos de la lengua</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/DA.html">Diccionario de autoridades</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://apps.rae.es/ntlle/SrvltGUISalirNtlle">Nuevo tesoro lexicográfico</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/ntllet/SrvltGUILoginNtlletPub">Mapa de diccionarios</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/DH1936.html">Diccionario histórico (1933-1936)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/DH.html">Diccionario histórico (1960-1996)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/drae2001/">Diccionario de la lengua española (2001)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/desen/">Diccionario esencial (2006)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/formulario-de-la-unidad-interactiva-del-diccionario" title="Envíe las propuestas y sugerencias externas relacionadas con el «Diccionario de la lengua española»">Unidad Interactiva del Diccionario (UNIDRAE)</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Banco de datos</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/corpes/">CORPES XXI</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/CNDHE/">CDH</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://corpus.rae.es/creanet.html">CREA</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/crea-anotado/" title="CREA anotado">CREA anotado</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://corpus.rae.es/cordenet.html">CORDE</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/fichero.html">Fichero general</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.asale.org/corpus-asale/">Corpus ASALE</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Gramática</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://aplica.rae.es/grweb/cgi-bin/buscar.cgi">Nueva gramática de la lengua española</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/gtg/">Glosario de términos gramaticales</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/sites/default/files/Gramatica_RAE_1771_reducida.pdf">Primera gramática</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/gram%C3%A1tica-b%C3%A1sica/" title="Nueva gramática básica de la lengua española">Nueva gramática básica de la lengua española</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Ortografía</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://aplica.rae.es/orweb/cgi-bin/buscar.cgi">Ortografía 2010</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="/sites/default/files/Ortografia_RAE_1741_reducida.pdf">Primera ortografía</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/ortograf%C3%ADa-b%C3%A1sica/" title="Ortografía básica de la lengua española">Ortografía básica de la lengua española</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Biblioteca</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca/biblioteca-academica">Biblioteca académica</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca/legado-antonio-rodriguez-monino-y-maria-brey">Legado Rodríguez-Moñino</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca/legado-damaso-alonso">Legado Dámaso Alonso</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca-digital" title="Biblioteca Digital">Biblioteca Digital</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Archivo</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://archivo.rae.es/">Fondo institucional</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://archivo.rae.es/index.php/coleccion-de-autografos-de-pedro-antonio-de-alarcon">Colección P. A. de Alarcón</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://archivo.rae.es/zorrilla/">Zorrilla</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/manuscritos-para-la-segunda-edicion-del-diccionario-de-autoridades">2.ª edición del «Diccionario de autoridades»</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://archivo.rae.es/fichero-de-hilo">Fichero de hilo</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Boletines</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://revistas.rae.es/bilrae/">BILRAE</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://revistas.rae.es/brae">BRAE</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span title="Recursos académicos de apoyo para el lenguaje claro">Lenguaje claro</span>
+          </div>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Enclave</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://enclavedeciencia.rae.es/inicio">Enclave de Ciencia</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Enlaces externos</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://asines.org/">Atlas sintáctico del español</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/dhecan.html">Diccionario Histórico del Español de Canarias</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/CORLEXIN.html">Corpus Léxico de Inventarios</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://lla.unileon.es/" title="Léxico leonés actual">Léxico leonés actual</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+    
+  </ul>
+  
+
+
+        </div>
+      </div>
+
+
+    </div>
+
+  </div>
+</div>
+
+</div>
+
+  </div>
+
+      
+
+    </div>
+
+    
+
+
+  <script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script src="/sites/default/files/js/js_b-ar_0H4iDIMUsW8GfJsDFfYU0G5JxN3w3EHDaWDWFw.js"></script>\n<script src="/damer/js/20210406.js"></script>
+<!--[if IE]>
+<style>
+#deletex{ display:none;}
+</style>
+<![endif]-->
+</body>
+<script>
+window.cat='EXTERNO';window.acc='www.rae.es/damer/country';window.eti='';
+</script>
+</html>

--- a/tests/cogs/damer_sample_htmls/dne.html
+++ b/tests/cogs/damer_sample_htmls/dne.html
@@ -1,0 +1,1352 @@
+<!DOCTYPE html>
+<html lang="es">
+<head><noscript><style>form.antibot * :not(.antibot-message) { display: none !important; }</style></noscript>
+<link rel="preload" href="/sites/default/files/css/css_2toHNXfbnPicu5GM0gX9NZ5orfKOc_JkPXeCbZqaWws.css" as="style">
+<link rel="preload" href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&amp;display=swap" as="style">
+<link rel="preload" href="https://fonts.googleapis.com/css2?family=Merriweather:wght@700&amp;display=swap" as="style">
+<link rel="preload" href="/sites/default/files/css/css_MKU0IOMhjZnRGgSeMxmlSpwNVcEMZOFPTb3EZkC-BVI.css" as="style">
+<link rel="preload" href="/sites/default/files/js/js_7hSOT9HVKxMvGlrclR4TDcqOUtAR-0e88Vkq_P_PROE.js" as="script">
+<link rel="preload" href="/damer/css/20201019.css" as="style">
+<link rel="preload" href="/damer/js/20210406.js" as="script">
+<link rel="preload" href="/themes/custom/front/assets/fonts/lato/lato-bold-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/lato/lato-regular-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/merriweather/merriweather-black-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/merriweather/merriweather-light-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/merriweather/merriweather-regular-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="canonical" href="https://www.asale.org/damer/"/>
+<title>Diccionario de americanismos | ASALE</title>
+<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="Versión electrónica del «Diccionario de americanismos» da respuesta, desde el punto de vista de la norma culta actual, a las dudas lingüísticas más habituales (ortográficas, léxicas y gramaticales) que plantea el uso del español."/>
+<meta name="keywords" content="asale, asale.org, asociacion de academinas, asociacion de academinas de la lengua, español, diccionario, dictionary, lengua, language, ortografía, orthography, gramática, grammar, lexicografía, lexicography, damer, diccionario de americanismos, diccionario español"/>
+<meta name="author" content="ASALE"/>
+<meta name="robots" content="noindex,follow"/>
+<meta name="rating" content="safe for kids"/>
+<meta name="rights" content="Asociación de Academias de la Lengua Española © Todos los derechos reservados"/>
+<meta name="author" content="ASALE">
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:site" content="\@ASALEinforma"/>
+<meta name="twitter:url" content="https://www.asale.org/damer/"/>
+<meta name="twitter:title" content="Diccionario de americanismos"/>
+<meta name="twitter:description" content="Versión electrónica del «Diccionario de americanismos» da respuesta, desde el punto de vista de la norma culta actual, a las dudas lingüísticas más habituales (ortográficas, léxicas y gramaticales) que plantea el uso del español."/>
+<meta name="twitter:image" content="/damer/img/logo-asale.png"/>
+<meta name="twitter:image:alt" content="«Diccionario de americanismos»"/>
+<meta property="article:author" content="https://es-es.facebook.com/asale"/>
+<meta property="og:title" content="Diccionario de americanismos"/>
+<meta property="og:type" content="website"/>
+<meta property="og:site_name" content="«Diccionario de americanismos»"/>
+<meta property="og:url" content="https://www.asale.org/damer/"/>
+<meta property="og:description" content="Versión electrónica del «Diccionario de americanismos» da respuesta, desde el punto de vista de la norma culta actual, a las dudas lingüísticas más habituales (ortográficas, léxicas y gramaticales) que plantea el uso del español."/>
+<meta property="og:locale" content="es"/>
+<meta property="og:image" content="/damer/img/logo-asale.png"/>
+<meta property="og:image:type" content="image/png"/>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<link rel="shortcut icon" href="/themes/custom/front/favicon.ico" />
+<link rel="mask-icon" href="/themes/custom/front/src/assets/images/favicons/safari-pinned-tab.svg" />
+<link rel="icon" sizes="16x16" href="/themes/custom/front/src/assets/images/favicons/favicon-16x16.png" />
+<link rel="icon" sizes="32x32" href="/themes/custom/front/src/assets/images/favicons/favicon-32x32.png" />
+<link rel="apple-touch-icon" sizes="180x180" href="/themes/custom/front/src/assets/images/favicons/apple-touch-icon.png" />
+<link rel="apple-touch-icon-precomposed" sizes="180x180" href="/themes/custom/front/src/assets/images/favicons/apple-touch-icon.png" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=2, minimum-scale=1, user-scalable=yes" />
+<!--[if lt IE 9]><script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+<link rel="stylesheet" media="all" href="/sites/default/files/css/css_2toHNXfbnPicu5GM0gX9NZ5orfKOc_JkPXeCbZqaWws.css"/>
+<link rel="stylesheet" media="all" href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&amp;display=swap"/>
+<link rel="stylesheet" media="all" href="https://fonts.googleapis.com/css2?family=Merriweather:wght@700&amp;display=swap"/>
+<link rel="stylesheet" media="all" href="/sites/default/files/css/css_MKU0IOMhjZnRGgSeMxmlSpwNVcEMZOFPTb3EZkC-BVI.css"/>
+<script>window.a2a_config=window.a2a_config||{};a2a_config.callbacks=[];a2a_config.overlays=[];a2a_config.templates={};a2a_config.static_server= "http://www.asale.org/sites/default/files/addtoany/menu/oafg07ee";a2a_config.icon_color = "transparent,#000";</script>
+
+<link rel="stylesheet" media="all" href="/damer/css/20201019.css"/>
+</head>
+<body class="path--node body-sidebars-none alias--noticia-primera-reunion-plenaria-virtual-de-directores-y-presidentes-de-las-academias-de-la-lengua nodetype--noticia logged-out" data-aos-easing="ease" data-aos-duration="400" data-aos-delay="0">
+<div role="main">
+<div class="dialog-off-canvas-main-canvas" data-off-canvas-main-canvas="">
+<div class="page-standard" id="pg__c">
+
+<header id="header" class="header">
+
+  <div class="header__logo">
+    <div class="img">
+                <a href="/" title="Inicio - ASALE" rel="home" class="site-logo">
+            <img src="/themes/custom/asale/assets/images/logo-asale.png" alt="Logo ASALE"/>
+          </a>
+          </div>
+  </div>
+
+  <div class="header-menu-search">
+
+    <nav class="header-menu">
+
+      <div class="main-menu-container">
+        <span class="menu-buttom__close">
+  <svg class="icon icon--xsmall icon-black">
+    <title>cerrar</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#close"></use>
+  </svg>
+</span>
+        
+
+<nav role="navigation" aria-labelledby="block-navegacionprincipalasale" id="block-navegacionprincipalasale" class="block block-menu navigation block-system-menublock menu--main-asale">
+      
+        
+
+
+              <ul class="menu-list main">
+              <li class="menu-list__item" >
+
+                  <div class="parent-item">
+            <a href="/la-asociacion" data-drupal-link-system-path="node/29051">La Asociación</a>
+            <span class="menu-collapse">
+              <svg class="icon icon--xsmall icon-black">
+                <title>Abrir submenu</title>
+                <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-bottom"></use>
+              </svg>
+            </span>
+          </div>
+        
+
+                                <ul>
+              <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/bienvenida" data-drupal-link-system-path="node/31480">Bienvenida</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/presentacion" data-drupal-link-system-path="node/31494">Presentación</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/comision-permanente" data-drupal-link-system-path="node/29478">Comisión Permanente</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/politica-panhispanica" data-drupal-link-system-path="node/31648">Política panhispánica</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/actividad-institucional" data-drupal-link-system-path="node/31515">Actividad institucional</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/biblioteca-de-la-asale" data-drupal-link-system-path="node/31634">Biblioteca de la ASALE</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/conmemoraciones" data-drupal-link-system-path="node/31641">Conmemoraciones</a>
+        
+
+              </li>
+      </ul>
+    
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/academias" data-drupal-link-system-path="academias">Academias</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <div class="parent-item">
+            <a href="/obras" data-drupal-link-system-path="node/29030">Obras</a>
+            <span class="menu-collapse">
+              <svg class="icon icon--xsmall icon-black">
+                <title>Abrir submenu</title>
+                <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-bottom"></use>
+              </svg>
+            </span>
+          </div>
+        
+
+                                <ul>
+              <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/diccionarios" data-drupal-link-system-path="taxonomy/term/100">Diccionarios</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/gramatica" data-drupal-link-system-path="taxonomy/term/101">Gramática</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/ortografia" data-drupal-link-system-path="taxonomy/term/102">Ortografía</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/ediciones-conmemorativas" data-drupal-link-system-path="taxonomy/term/103">Ediciones conmemorativas</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/clasicos-asale" data-drupal-link-system-path="taxonomy/term/337">Clásicos ASALE</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/otras-obras" data-drupal-link-system-path="taxonomy/term/330">Otras obras</a>
+        
+
+              </li>
+      </ul>
+    
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/corpus" data-drupal-link-system-path="node/29037">Corpus</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <div class="parent-item">
+            <a href="/escuela-de-lexicografia" data-drupal-link-system-path="node/29044">Escuela de Lexicografía</a>
+            <span class="menu-collapse">
+              <svg class="icon icon--xsmall icon-black">
+                <title>Abrir submenu</title>
+                <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-bottom"></use>
+              </svg>
+            </span>
+          </div>
+        
+
+                                <ul>
+              <li class="menu-list__item" >
+
+                  <a href="/escuela-de-lexicografia/la-elh" data-drupal-link-system-path="node/32131">La ELH</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/escuela-de-lexicografia/master-de-lexicografia-hispanica-y-correccion-linguistica" data-drupal-link-system-path="node/88530">Máster</a>
+        
+
+              </li>
+      </ul>
+    
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/publicaciones" data-drupal-link-system-path="node/28988">Publicaciones</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/noticias" data-drupal-link-system-path="noticias">Noticias</a>
+        
+
+              </li>
+      </ul>
+    
+
+
+  </nav>
+      </div>
+
+      <ul class="search-block">
+        <li class="menu-list__item link-dle">
+          <svg class="icon icon--tiny icon-white">
+            <title>Recursos</title>
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#diccionarios"></use>
+          </svg>
+          <span class="menu-list__text">Recursos</span>
+        </li>
+        <li class="menu-list__item link-search">
+          <svg class="icon icon--xsmall icon-white">
+            <title>Buscador</title>
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#lupa"></use>
+          </svg>
+        </li>
+        <li class="menu-list__item link-menu">
+          <svg class="icon icon--small icon-white">
+            <title>Menu</title>
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#menu"></use>
+          </svg>
+        </li>
+      </ul>
+
+    </nav>
+  </div>
+</header>
+<div class="container">
+<div class="row">
+<div class="col-xs-12 col-md-8" style="border-right:1px solid #ccc">  
+<div style="margin: 20px 0 10px 0;font-size:2em"><a href="/damer/">Diccionario de americanismos</a></div>
+<div class="form-box-wrapper">
+<div class="form-box"><form action="#" method="post" class="form form-damer" id="formulario"><input size="30" style="border:1px solid #ccc" class="custom-search-box" name="w" id="wq" type="text" value="" placeholder="Escriba aquí la palabra" autocomplete="off" autocapitalize="off"/><input style="margin-left:5px" alt="Buscar" type="image" class="icon icon--xsmall icon-grey" src="/themes/custom/front/src/assets/images/lupa.svg" name="submit"></form></div>
+<div class="addtext"><a style="" href="javascript:addText('á','damer');">á</a><a style="" href="javascript:addText('é','damer');">é</a><a style="" href="javascript:addText('í','damer');">í</a><a style="" href="javascript:addText('ó','damer');">ó</a><a style="" href="javascript:addText('ú','damer');">ú</a><a style="" href="javascript:addText('ü','damer');">ü</a><a style="" href="javascript:addText('ñ','damer');">ñ</a></div>
+</div>
+
+<div class="bloque-txt" id="resultados">Aviso: <span>La palabra <b>asd</b> no está en el Diccionario.</span> Las entradas que se muestran a continuación podrían estar relacionadas:</p><div class='item-list'><div class='n1'><a data-cat='FETCH' data-acc='LISTA APROX' data-eti='asa' title='Ir a la entrada' href='/damer/asa'>asa</a> (asa)</div><div class='n1'><a data-cat='FETCH' data-acc='LISTA APROX' data-eti='así' title='Ir a la entrada' href='/damer/así'>así</a> (así)</div></div><p class="o"><center><i><span class="d7">Diccionario de americanismos © 2010<br/>Asociación de Academias de la Lengua Española © Todos los derechos reservados</span></i></center></p><div class="compartir"><a title="Compartir en Facebook" class="resp-sharing-button__link" href="https://facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.asale.org%2Fdamer%2F" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--facebook resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M18.77 7.46H14.5v-1.9c0-.9.6-1.1 1-1.1h3V.5h-4.33C10.24.5 9.5 3.44 9.5 5.32v2.15h-3v4h3v12h5v-12h3.85l.42-4z"/></svg></div></div></a>
+<a title="Compartir en Twitter" class="resp-sharing-button__link" href="https://twitter.com/intent/tweet/?text=Diccionario de americanismos&url=https%3A%2F%2Fwww.asale.org%2Fdamer%2F" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--twitter resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M23.44 4.83c-.8.37-1.5.38-2.22.02.93-.56.98-.96 1.32-2.02-.88.52-1.86.9-2.9 1.1-.82-.88-2-1.43-3.3-1.43-2.5 0-4.55 2.04-4.55 4.54 0 .36.03.7.1 1.04-3.77-.2-7.12-2-9.36-4.75-.4.67-.6 1.45-.6 2.3 0 1.56.8 2.95 2 3.77-.74-.03-1.44-.23-2.05-.57v.06c0 2.2 1.56 4.03 3.64 4.44-.67.2-1.37.2-2.06.08.58 1.8 2.26 3.12 4.25 3.16C5.78 18.1 3.37 18.74 1 18.46c2 1.3 4.4 2.04 6.97 2.04 8.35 0 12.92-6.92 12.92-12.93 0-.2 0-.4-.02-.6.9-.63 1.96-1.22 2.56-2.14z"/></svg></div></div></a>
+<a title="Compartir por correo electrónico" class="resp-sharing-button__link" href="/cdn-cgi/l/email-protection#a798d4d2c5cdc2c4d39ae3cec4c4cec8c9c6d5cec887c3c287c6cac2d5cec4c6c9ced4cac8d481c5c8c3de9acfd3d3d7d49d8888d0d0d089c6d4c6cbc289c8d5c088c3c6cac2d5888297e68297e6f1c2d5d4ce6414c987c2cbc2c4d3d56414c9cec4c687c3c2cb87650ce3cec4c4cec8c9c6d5cec887c3c287c6cac2d5cec4c6c9ced4cac8d4651c87c3c687d5c2d4d7d2c2d4d3c68b87c3c2d4c3c287c2cb87d7d2c9d3c887c3c287d1ced4d3c687c3c287cbc687c9c8d5cac687c4d2cbd3c687c6c4d3d2c6cb8b87c687cbc6d487c3d2c3c6d487cbcec9c0641b640ad4d3cec4c6d487ca6406d487cfc6c5ced3d2c6cbc2d4878fc8d5d3c8c0d56406c1cec4c6d48b87cb640edfcec4c6d487de87c0d5c6cac6d3cec4c6cbc2d48e87d6d2c287d7cbc6c9d3c2c687c2cb87d2d4c887c3c2cb87c2d4d7c66416c8cb89" target="_self" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--email resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M22 4H2C.9 4 0 4.9 0 6v12c0 1.1.9 2 2 2h20c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zM7.25 14.43l-3.5 2c-.08.05-.17.07-.25.07-.17 0-.34-.1-.43-.25-.14-.24-.06-.55.18-.68l3.5-2c.24-.14.55-.06.68.18.14.24.06.55-.18.68zm4.75.07c-.1 0-.2-.03-.27-.08l-8.5-5.5c-.23-.15-.3-.46-.15-.7.15-.22.46-.3.7-.14L12 13.4l8.23-5.32c.23-.15.54-.08.7.15.14.23.07.54-.16.7l-8.5 5.5c-.08.04-.17.07-.27.07zm8.93 1.75c-.1.16-.26.25-.43.25-.08 0-.17-.02-.25-.07l-3.5-2c-.24-.13-.32-.44-.18-.68s.44-.32.68-.18l3.5 2c.24.13.32.44.18.68z"/></svg></div></div></a>
+<a title="Compartir en WhatsApp" class="resp-sharing-button__link" href="whatsapp://send?text=Diccionario de americanismos%20https%3A%2F%2Fwww.asale.org%2Fdamer%2F" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--whatsapp resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20.1 3.9C17.9 1.7 15 .5 12 .5 5.8.5.7 5.6.7 11.9c0 2 .5 3.9 1.5 5.6L.6 23.4l6-1.6c1.6.9 3.5 1.3 5.4 1.3 6.3 0 11.4-5.1 11.4-11.4-.1-2.8-1.2-5.7-3.3-7.8zM12 21.4c-1.7 0-3.3-.5-4.8-1.3l-.4-.2-3.5 1 1-3.4L4 17c-1-1.5-1.4-3.2-1.4-5.1 0-5.2 4.2-9.4 9.4-9.4 2.5 0 4.9 1 6.7 2.8 1.8 1.8 2.8 4.2 2.8 6.7-.1 5.2-4.3 9.4-9.5 9.4zm5.1-7.1c-.3-.1-1.7-.9-1.9-1-.3-.1-.5-.1-.7.1-.2.3-.8 1-.9 1.1-.2.2-.3.2-.6.1s-1.2-.5-2.3-1.4c-.9-.8-1.4-1.7-1.6-2-.2-.3 0-.5.1-.6s.3-.3.4-.5c.2-.1.3-.3.4-.5.1-.2 0-.4 0-.5C10 9 9.3 7.6 9 7c-.1-.4-.4-.3-.5-.3h-.6s-.4.1-.7.3c-.3.3-1 1-1 2.4s1 2.8 1.1 3c.1.2 2 3.1 4.9 4.3.7.3 1.2.5 1.6.6.7.2 1.3.2 1.8.1.6-.1 1.7-.7 1.9-1.3.2-.7.2-1.2.2-1.3-.1-.3-.3-.4-.6-.5z"/></svg></div></div></a>
+<a title="Compartir en Telegram" class="resp-sharing-button__link" href="https://telegram.me/share/url?text=Diccionario de americanismos&url=https%3A%2F%2Fwww.asale.org%2Fdamer%2F" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--telegram resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M.707 8.475C.275 8.64 0 9.508 0 9.508s.284.867.718 1.03l5.09 1.897 1.986 6.38a1.102 1.102 0 0 0 1.75.527l2.96-2.41a.405.405 0 0 1 .494-.013l5.34 3.87a1.1 1.1 0 0 0 1.046.135 1.1 1.1 0 0 0 .682-.803l3.91-18.795A1.102 1.102 0 0 0 22.5.075L.706 8.475z"/></svg></div></div></a>
+<a title="Compartir en Pinterest" class="resp-sharing-button__link" href="https://pinterest.com/pin/create/button/?url=https%3A%2F%2Fwww.asale.org%2Fdamer%2F&media=https%3A%2F%2Fwww.asale.org%2Fdamer%2F&description=Versión electrónica del «Diccionario de americanismos» da respuesta, desde el punto de vista de la norma culta actual, a las dudas lingüísticas más habituales (ortográficas, léxicas y gramaticales) que plantea el uso del español." target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--pinterest resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.14.5C5.86.5 2.7 5 2.7 8.75c0 2.27.86 4.3 2.7 5.05.3.12.57 0 .66-.33l.27-1.06c.1-.32.06-.44-.2-.73-.52-.62-.86-1.44-.86-2.6 0-3.33 2.5-6.32 6.5-6.32 3.55 0 5.5 2.17 5.5 5.07 0 3.8-1.7 7.02-4.2 7.02-1.37 0-2.4-1.14-2.07-2.54.4-1.68 1.16-3.48 1.16-4.7 0-1.07-.58-1.98-1.78-1.98-1.4 0-2.55 1.47-2.55 3.42 0 1.25.43 2.1.43 2.1l-1.7 7.2c-.5 2.13-.08 4.75-.04 5 .02.17.22.2.3.1.14-.18 1.82-2.26 2.4-4.33.16-.58.93-3.63.93-3.63.45.88 1.8 1.65 3.22 1.65 4.25 0 7.13-3.87 7.13-9.05C20.5 4.15 17.18.5 12.14.5z"/></svg></div></div></a>
+<a title="Compartir en LinkedIn" class="resp-sharing-button__link" href="https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fwww.asale.org%2Fdamer%2F&title=Diccionario de americanismos&summary=Versión electrónica del «Diccionario de americanismos» da respuesta, desde el punto de vista de la norma culta actual, a las dudas lingüísticas más habituales (ortográficas, léxicas y gramaticales) que plantea el uso del español.&source=https%3A%2F%2Fwww.asale.org%2Fdamer%2F" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--linkedin resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
+<svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M6.5 21.5h-5v-13h5v13zM4 6.5C2.5 6.5 1.5 5.3 1.5 4s1-2.4 2.5-2.4c1.6 0 2.5 1 2.6 2.5 0 1.4-1 2.5-2.6 2.5zm11.5 6c-1 0-2 1-2 2v7h-5v-13h5V10s1.6-1.5 4-1.5c3 0 5 2.2 5 6.3v6.7h-5v-7c0-1-1-2-2-2z"/></svg></div></div></a></div></div>
+</div>
+<div data-nosnippet class="col-xs-12 col-md-4 bloque-txt">
+<h2 class="ayuda">Más información</h2>
+<div class="view-node-navigation"><ul class="menu"><li class="leaf d0"><a target="_blank" title="Prólogo de la obra" class="tooltip" href="https://www.asale.org/sites/default/files/Prologo_Diccionario_de_americanismos.pdf">Prólogo</a> de la obra</li><li class="leaf d0"><a target="_blank" title="Preliminares (abreviaturas) de la obra" class="tooltip" href="https://www.asale.org/sites/default/files/Abreviaturas_del_DA.pdf">Preliminares</a> (abreviaturas) de la obra</li></ul></div>
+
+    
+<div><h2 class="ayuda">Rueda de palabras</h2>
+<div>
+<ul class='rueda'><li><a href='/damer/kechi'>kechi</a></li><li><a href='/damer/kechu'>kechu</a></li><li><a href='/damer/keep'>keep</a></li><li><a href='/damer/keki'>keki</a></li><li><a href='/damer/kelli'>kelli</a></li><li><a href='/damer/kelper'>kelper</a></li><li><a href='/damer/ken'>ken</a></li><li><a href='/damer/kenaf'>kenaf</a></li><li><a href='/damer/kenchachar'>kenchachar</a></li><li><a href='/damer/kenep'>kenep</a></li><li><a href='/damer/kengue'>kengue</a></li><li><a href='/damer/kenke'>kenke</a></li><li><a href='/damer/kenton'>kenton</a></li><li><a href='/damer/keperi'>keperi</a></li><li><a href='/damer/keperí'>keperí</a></li></ul></div>
+</div>
+</div>
+</div>
+</div>
+<div data-nosnippet class="clearfix" id="main">
+    <div data-nosnippet class="cog--mq mq-main">
+
+            <section class="section section--secondary o-section--large">
+  <div data-nosnippet class="container">
+
+    <h2 class="section__title" data-aos="fade-up" data-aos-offset="50" data-aos-delay="200" data-aos-duration="1000">
+      <span class="divider__title"></span>
+      También le interesará
+    </h2>
+
+    <div data-nosnippet class="row">
+
+      <div data-nosnippet class="col-xs-12 col-md-6 col-lg-3"
+           data-aos="fade-up"
+           data-aos-offset="150"
+           data-aos-delay="400"
+           data-aos-duration="800">
+          <div data-nosnippet class="views-element-container">
+<div data-nosnippet class="js-view-dom-id-02a2d65813f4ad19486655be44ae3d013bf874ea18cdb029038d81b8f502454b vista">
+    
+    
+    
+
+    
+    
+    
+
+    
+
+  
+
+<div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/noticia/la-asociacion-de-academias-de-la-lengua-espanola-celebra-su-70o-aniversario-bajo-la">70 AÑOS DE ASALE</a></p>
+
+      <div data-nosnippet class="block-news__img img">
+      <a target="_self" title="Actos de celebración del 70 aniversario" href="/noticia/la-asociacion-de-academias-de-la-lengua-espanola-celebra-su-70o-aniversario-bajo-la">
+        <img class="b-lazy"
+             src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+             data-src="/sites/default/files/styles/tambien_interesa/public/2021-12/70%20anos%20asale.jpg?itok=kU8Y2JlT"
+             alt="Los reyes de España han presidido en el salón de actos de la RAE el solemne acto institucional conmemorativo del septuagésimo aniversario de la Asociación de Academias de la Lengua Española (ASALE). Foto: RAE. " />
+      </a>
+    </div>
+  
+      <span class="news__date">
+      
+    </span>
+  
+  <p class="block-news__title u-text-brandsecondary">
+    <a target="_self" title="Actos de celebración del 70 aniversario" href="/noticia/la-asociacion-de-academias-de-la-lengua-espanola-celebra-su-70o-aniversario-bajo-la">
+      Actos de celebración del 70 aniversario
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+
+  
+
+<div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/obras-academicas/clasicos-asale">Clásicos ASALE</a></p>
+
+      <div data-nosnippet class="block-news__img img">
+      <a target="_self" title="Conozca los títulos de toda la colección" href="/obras-academicas/clasicos-asale">
+        <img class="b-lazy"
+             src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+             data-src="/sites/default/files/styles/tambien_interesa/public/imagenes/articulos/Foto_La_Voz_de_Galicia_1_1.png?itok=nG30FJfh"
+             alt="Nuevos títulos de la colección Clásicos ASALE  " />
+      </a>
+    </div>
+  
+      <span class="news__date">
+      
+    </span>
+  
+  <p class="block-news__title u-text-brandsecondary">
+    <a target="_self" title="Conozca los títulos de toda la colección" href="/obras-academicas/clasicos-asale">
+      Conozca los títulos de toda la colección
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+
+        
+
+    
+    
+
+    
+</div>
+</div>
+
+      </div>
+
+
+      <div data-nosnippet class="col-xs-12 col-md-6 col-lg-8 u-border-left"
+           data-aos="fade-up"
+           data-aos-offset="150"
+           data-aos-delay="400"
+           data-aos-duration="800">
+          <div data-nosnippet class="views-element-container">
+<div data-nosnippet class="js-view-dom-id-b5df2b64bbf6d0641e267cd9ab9d13eb19064524d5085d5ec1cde593ffb30d5b vista">
+    
+    
+    
+
+    
+    
+    
+
+    
+<div data-nosnippet class="row">
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/lexicografia" hreflang="es">Lexicografía</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Cuarta convocatoria del Programa ASALE de becas de formación y colaboración destinado a las academias de la Asociación de Academias de la Lengua Española (ASALE) " href="/noticia/cuarta-convocatoria-del-programa-asale-de-becas-de-formacion-y-colaboracion-destinado-las">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/imagenes/articulos/centro_de_estudios_RAE_serrano.jpg?h=c9f93661&amp;itok=zfPMAJv-"
+               alt="Sede de la Escuela de Lexicografía (Serrano, 187-189) en Madrid (foto: RAE)">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2025-05-27T12:00:00Z">27 de Mayo de 2025</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Cuarta convocatoria del Programa ASALE de becas de formación y colaboración destinado a las academias de la Asociación de Academias de la Lengua Española (ASALE) " href="/noticia/cuarta-convocatoria-del-programa-asale-de-becas-de-formacion-y-colaboracion-destinado-las">
+      <span>Cuarta convocatoria del Programa ASALE de becas de formación y colaboración destinado a las academias de la Asociación de Academias de la Lengua Española (ASALE) </span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/academicos" hreflang="es">Académicos</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Carlos Martini, nuevo miembro de número de la Academia Paraguaya de la Lengua Española" href="/noticia/carlos-martini-nuevo-miembro-de-numero-de-la-academia-paraguaya-de-la-lengua-espanola">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/2021-11/Sede_APARLE.jpg?h=9e499333&amp;itok=BhYtrdjy"
+               alt="Sede de la Academia Paraguaya de la Lengua Española">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2025-01-13T12:00:00Z">13 de Enero de 2025</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Carlos Martini, nuevo miembro de número de la Academia Paraguaya de la Lengua Española" href="/noticia/carlos-martini-nuevo-miembro-de-numero-de-la-academia-paraguaya-de-la-lengua-espanola">
+      <span>Carlos Martini, nuevo miembro de número de la Academia Paraguaya de la Lengua Española</span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/obituarios" hreflang="es">Obituarios</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Fallece Tarsicio Herrera Zapién, miembro de la Academia Mexicana de la Lengua" href="/noticia/fallece-tarsicio-herrera-zapien-miembro-de-la-academia-mexicana-de-la-lengua">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/imagenes/academicos/Tarsicio_Herrera_Sapien_www.cultura.gob_.mx_.jpg?h=c9f93661&amp;itok=XE1zuFdY"
+               alt="Tarsicio Herrera Zapién, miembro de número de la Academia Mexicana de la Lengua. Foto: Secretaría de Cultura.">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2026-02-05T12:00:00Z">5 de Febrero de 2026</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Fallece Tarsicio Herrera Zapién, miembro de la Academia Mexicana de la Lengua" href="/noticia/fallece-tarsicio-herrera-zapien-miembro-de-la-academia-mexicana-de-la-lengua">
+      <span>Fallece Tarsicio Herrera Zapién, miembro de la Academia Mexicana de la Lengua</span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/academicos" hreflang="es">Académicos</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Félix Julio Alfonso López ingresa en la Academia Cubana de la Lengua" href="/noticia/felix-julio-alfonso-lopez-ingresa-en-la-academia-cubana-de-la-lengua">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/2026-02/F%C3%A9lix%20Julio%20Alfonso%20L%C3%B3pez_0.jpg?h=8b436e18&amp;itok=6lYXMiAr"
+               alt="Félix Julio Alfonso López">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2026-02-04T12:00:00Z">4 de Febrero de 2026</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Félix Julio Alfonso López ingresa en la Academia Cubana de la Lengua" href="/noticia/felix-julio-alfonso-lopez-ingresa-en-la-academia-cubana-de-la-lengua">
+      <span>Félix Julio Alfonso López ingresa en la Academia Cubana de la Lengua</span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+  </div>
+
+        
+
+    
+    
+
+    
+</div>
+</div>
+
+      </div>
+
+
+    </div>
+  </div>
+</section>
+
+            <section class="section o-section--medium">
+
+  <div data-nosnippet class="container">
+    <div data-nosnippet class="u-text-center">
+
+      <div data-nosnippet class="btn btn-up" data-aos="fade-up" data-aos-offset="50" data-aos-delay="200" data-aos-duration="1000">
+        <a href="#main" class="ancla">
+          <svg class="icon icon--small icon-black">
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-up"></use>
+          </svg>
+          <p class="btn__text">Arriba</p>
+        </a>
+      </div>
+
+    </div>
+  </div>
+
+</section>
+
+    </div>
+  </div>
+
+  
+  <footer id="footer" class="footer">
+  <div data-nosnippet class="container">
+    <div data-nosnippet class="pre-footer">
+
+      <p class="footer-privacidad">
+        REAL ACADEMIA ESPAÑOLA. Finalidades: Recopilación de información lingüística para la investigación, desarrollo, proyección y buen uso de la lengua española en el ámbito de la IA (proyecto LEIA). Derechos: tiene derecho a acceder, rectificar y suprimir sus datos, así como a otros derechos como se explica en la información adicional y detallada que se puede consultar en nuestra 
+        <span class="privacidad-link privacidad-link--inverse"><a href="/politica-de-privacidad-y-proteccion-de-los-datos-personales" target="_blank">política de privacidad</a>.</span>
+      </p>
+
+    </div>
+
+    <div data-nosnippet class="sub-footer">
+      <div data-nosnippet class="sub-footer__social">
+        <a title="Síganos en X" href="https://x.com/RAEinforma" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en X</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#twitter"></use>
+    </svg>
+</a>
+<a title="Síganos en Facebook"  href="https://www.facebook.com/RAE/" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en Facebook</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#facebook"></use>
+    </svg>
+</a>
+<a title="Visite nuestro Instagram" href="https://www.instagram.com/laraeinforma/" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Visite nuestro Instagram</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#instagram"></use>
+    </svg>
+</a>
+<a title="Síganos en TikTok" href="https://www.tiktok.com/@rae.informa" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en TikTok</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#tiktok"></use>
+    </svg>
+</a>
+<a title="Visite nuestras galerías" href="https://www.flickr.com/photos/raeinforma" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Visite nuestras galerías</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#flicker"></use>
+    </svg>
+</a>
+<a title="Síganos en Youtube" href="https://www.youtube.com/user/RAEInforma" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en Youtube</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#youtube"></use>
+    </svg>
+</a>
+
+<a title="Escuche nuestras listas de música" href="https://open.spotify.com/user/u0gt78txho8qqa5m843kkvxy2" rel="noopener" target="_blank">
+  <svg class="icon icon--medium">
+    <title>Escuche nuestras listas de música</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#spoty"></use>
+  </svg>
+</a>
+
+<a title="Síganos en Souncloud" href="https://soundcloud.com/real-academia-espanola" rel="noopener" target="_blank">
+  <svg class="icon icon--medium">
+    <title>Síganos en Soundcloud</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#soundcloud"></use>
+  </svg>
+</a>
+
+<a title="Contacte con nosotros" href="/contacto-rae">
+  <svg class="icon icon--medium">
+    <title>Contacte con nosotros</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#email"></use>
+  </svg>
+</a>
+
+      </div>
+
+      <div data-nosnippet class="sub-footer__link">
+        <a title="Visitar Fundación pro-RAE" href="/fundacion">Fundación pro-Rae</a>
+        <a title="Visitar web ASALE" href="https://www.asale.org/" rel="noopener" target="_blank">Asale</a>
+      </div>
+
+
+      <p class="footer__text">
+        Felipe IV, 5 - 28014 Madrid - Teléfono:
+        <a title="Teléfono contacto" href="tel:34914201478">+34 91 420 14 78</a>
+        <span class="ml-1 d-inline-block">
+          © Real Academia Española, 2019
+        </span>
+      </p>
+
+      
+
+<nav role="navigation" aria-labelledby="block-piedepagina" id="block-piedepagina" class="block block-menu navigation block-system-menublock menu--footer">
+      
+        
+
+                        <ul class="footer-list">
+                            <li class="footer-list__item">
+                <a href="https://rae.whistlelink.com" target="_blank">Canal del informante</a>
+                            </li>
+                </ul>
+    
+
+
+  </nav>
+
+    </div>
+
+  </div>
+</footer>
+
+<div data-nosnippet class="search-full-container">
+  <span class="menu-buttom__close">
+  <svg class="icon icon--xsmall icon-black">
+    <title>cerrar</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#close"></use>
+  </svg>
+</span>
+  <div data-nosnippet class="container">
+
+    <div data-nosnippet class="header__logo">
+      <div data-nosnippet class="img">
+        <a href="/" title="Inicio - Real Academia Española" rel="home" class="site-logo">
+          <svg class="icon icon-logo">
+            <title>Logo RAE</title>
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#logo-rae"></use>
+          </svg>
+        </a>
+      </div>
+    </div>
+    <div data-nosnippet class="row justify-content-center">
+      <div data-nosnippet class="col-12 col-md-8">
+        <h2 class="search__title">Buscador general de la RAE</h2>
+
+        <form class="search-block-form" data-drupal-selector="search-block-form" action="/search/node" method="get" id="search-block-form" accept-charset="UTF-8">
+  <div data-nosnippet class="js-form-item form-item js-form-type-search form-type-search js-form-item-keys form-item-keys form-no-label">
+      <label for="edit-keys" class="visually-hidden">Search</label>
+        <input title="Escriba lo que quiere buscar." placeholder="Buscar en la web" data-drupal-selector="edit-keys" type="search" id="edit-keys" name="keys" value="" size="15" maxlength="128" class="form-search" />
+
+        </div>
+<div data-nosnippet data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions"><input alt="Buscar en la web" data-drupal-selector="edit-submit" type="image" id="edit-submit" name="op" src="/themes/custom/front/src/assets/images/lupa.svg" class="image-button js-form-submit form-submit" />
+</div>
+
+</form>
+
+      </div>
+    </div>
+  </div>
+</div>
+
+<div data-nosnippet class="dle-full-container">
+  <span class="menu-buttom__close">
+  <svg class="icon icon--xsmall icon-black">
+    <title>cerrar</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#close"></use>
+  </svg>
+</span>
+  <div data-nosnippet class="contenedor-full">
+
+    <div data-nosnippet class="container">
+      <div data-nosnippet class="row justify-content-between">
+
+        <div data-nosnippet class="col-xs-12 col-lg-7">
+          <div data-nosnippet class="diccionarios-container">
+            <h2 class="diccionarios-container__title">Diccionarios</h2>
+            <form class="diccionarios-form" data-drupal-selector="diccionarios-form" action="/" method="post" id="diccionarios-form" accept-charset="UTF-8">
+  <div data-nosnippet id="edit-diccionario"><div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dle" type="radio" id="edit-diccionario-dle" name="diccionario" value="dle" checked="checked" class="form-radio" />
+
+        <label for="edit-diccionario-dle" class="option">Diccionario de la lengua española</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dpd" type="radio" id="edit-diccionario-dpd" name="diccionario" value="dpd" class="form-radio" />
+
+        <label for="edit-diccionario-dpd" class="option">Diccionario panhispánico de dudas</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dpej" type="radio" id="edit-diccionario-dpej" name="diccionario" value="dpej" class="form-radio" />
+
+        <label for="edit-diccionario-dpej" class="option">Diccionario panhispánico del español jurídico</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dhle" type="radio" id="edit-diccionario-dhle" name="diccionario" value="dhle" class="form-radio" />
+
+        <label for="edit-diccionario-dhle" class="option">Diccionario histórico de la lengua española</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-damer" type="radio" id="edit-diccionario-damer" name="diccionario" value="damer" class="form-radio" />
+
+        <label for="edit-diccionario-damer" class="option">Diccionario de americanismos</label>
+      </div>
+</div>
+<fieldset data-drupal-selector="edit-caja" id="edit-caja" class="form-item js-form-wrapper form-wrapper">
+      <legend>
+    <span class="fieldset-legend"></span>
+  </legend>
+  <div data-nosnippet class="fieldset-wrapper">
+            <div data-nosnippet class="js-form-item form-item js-form-type-textfield form-type-textfield js-form-item-termino form-item-termino form-no-label">
+        <input aria-label="Término" data-drupal-selector="edit-termino" type="text" id="edit-termino" name="termino" value="" size="60" maxlength="128" placeholder="Escriba el término" class="form-text required" required="required" aria-required="true" />
+
+        </div>
+<input class="icon--small image-button js-form-submit form-submit" alt="Escriba el término" data-drupal-selector="edit-submit" type="image" id="edit-submit--2" name="op" src="/themes/custom/front/src/assets/images/lupa.svg" />
+
+          </div>
+</fieldset>
+<div data-nosnippet class="logo"><div data-nosnippet data-drupal-selector="edit-lacaixa-modal" data-drupal-states="{&quot;visible&quot;:[{&quot;:input[name=\u0022diccionario\u0022]&quot;:{&quot;value&quot;:&quot;dle&quot;}}]}" id="edit-lacaixa-modal" class="js-form-wrapper form-wrapper"><a title="Fundación “la Caixa”" rel="noopener" target="_blank" href="https://fundacionlacaixa.org/es/home"><img src="/themes/custom/front/src/assets/svg/logo-fundacion-caixa.svg" alt="Logo Obra social “la Caixa”"></a></div>
+</div><input autocomplete="off" data-drupal-selector="form-xia40oqp-xumj65oafjg5thtpkciat38yywr-l468i4" type="hidden" name="form_build_id" value="form-XIA40Oqp-xUMJ65oafjg5thtPkCIat38YyWR-l468I4" />
+<input data-drupal-selector="edit-diccionarios-form" type="hidden" name="form_id" value="diccionarios_form" />
+<div data-nosnippet data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions--3"></div>
+
+</form>
+
+          </div>
+        </div>
+        <div data-nosnippet class="col-xs-12 col-lg-4">
+          <div data-nosnippet class="dudas-container">
+            <h2 class="dudas-container__title">Dudas rápidas</h2>
+            <form class="dudas-form-modal" data-drupal-selector="dudas-form-modal" action="/" method="post" id="dudas-form-modal" accept-charset="UTF-8">
+  <fieldset data-drupal-selector="edit-caja-dudas-modal" id="edit-caja-dudas-modal" class="form-item js-form-wrapper form-wrapper">
+      <legend>
+    <span class="fieldset-legend"></span>
+  </legend>
+  <div data-nosnippet class="fieldset-wrapper">
+            <div data-nosnippet class="js-form-item form-item js-form-type-textfield form-type-textfield js-form-item-duda-modal form-item-duda-modal form-no-label">
+        <input aria-label="Término" data-drupal-selector="edit-duda-modal" type="text" id="edit-duda-modal" name="duda_modal" value="" size="60" maxlength="128" placeholder="Escriba las palabras clave" class="form-text required" required="required" aria-required="true" />
+
+        </div>
+<input class="icon--small image-button js-form-submit form-submit" alt="Buscar duda" data-drupal-selector="edit-submit-modal" type="image" id="edit-submit-modal" name="op" src="/themes/custom/front/src/assets/images/lupa.svg" />
+
+          </div>
+</fieldset>
+<input autocomplete="off" data-drupal-selector="form-cvfp2zsxkvagunug3dkccupvudyupyammxp4ka-jrzq" type="hidden" name="form_build_id" value="form-cvFP2zsxkVagunUg3dKcCupVUDYUPYAMMXp4kA-JRZQ" />
+<input data-drupal-selector="edit-dudas-form-modal" type="hidden" name="form_id" value="dudas_form_modal" />
+<div data-nosnippet data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions--5"></div>
+
+</form>
+
+          </div>
+        </div>
+      </div>
+
+      <div data-nosnippet class="recursos-container">
+        <h2 class="title__medium text-center mb-7">
+          Otros Recursos
+          <svg class="icon icon--xsmall icon-black">
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#plus"></use>
+          </svg>
+          <svg class="icon icon--xsmall icon-black hidden">
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#menos"></use>
+          </svg>
+        </h2>
+        <div data-nosnippet class="lista-recursos-container">
+          
+
+
+    
+          <ul class="lista-recursos" >
+    
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Diccionarios</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://dle.rae.es/">Diccionario de la lengua española</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/dpd/">Diccionario panhispánico de dudas</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://dpej.rae.es/">Diccionario panhispánico del español jurídico</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="/dhle">Diccionario histórico de la lengua española</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.asale.org/damer/">Diccionario de americanismos</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/diccionario-estudiante/" title="Diccionario del estudiante">Diccionario del estudiante</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/tdhle/" title="Tesoro de diccionarios históricos de la lengua">Tesoro de diccionarios históricos de la lengua</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/DA.html">Diccionario de autoridades</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://apps.rae.es/ntlle/SrvltGUISalirNtlle">Nuevo tesoro lexicográfico</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/ntllet/SrvltGUILoginNtlletPub">Mapa de diccionarios</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/DH1936.html">Diccionario histórico (1933-1936)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/DH.html">Diccionario histórico (1960-1996)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/drae2001/">Diccionario de la lengua española (2001)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/desen/">Diccionario esencial (2006)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/formulario-de-la-unidad-interactiva-del-diccionario" title="Envíe las propuestas y sugerencias externas relacionadas con el «Diccionario de la lengua española»">Unidad Interactiva del Diccionario (UNIDRAE)</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Banco de datos</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/corpes/">CORPES XXI</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/CNDHE/">CDH</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://corpus.rae.es/creanet.html">CREA</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/crea-anotado/" title="CREA anotado">CREA anotado</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://corpus.rae.es/cordenet.html">CORDE</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/fichero.html">Fichero general</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.asale.org/corpus-asale/">Corpus ASALE</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Gramática</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://aplica.rae.es/grweb/cgi-bin/buscar.cgi">Nueva gramática de la lengua española</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/gtg/">Glosario de términos gramaticales</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/sites/default/files/Gramatica_RAE_1771_reducida.pdf">Primera gramática</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/gram%C3%A1tica-b%C3%A1sica/" title="Nueva gramática básica de la lengua española">Nueva gramática básica de la lengua española</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Ortografía</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://aplica.rae.es/orweb/cgi-bin/buscar.cgi">Ortografía 2010</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="/sites/default/files/Ortografia_RAE_1741_reducida.pdf">Primera ortografía</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/ortograf%C3%ADa-b%C3%A1sica/" title="Ortografía básica de la lengua española">Ortografía básica de la lengua española</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Biblioteca</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca/biblioteca-academica">Biblioteca académica</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca/legado-antonio-rodriguez-monino-y-maria-brey">Legado Rodríguez-Moñino</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca/legado-damaso-alonso">Legado Dámaso Alonso</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca-digital" title="Biblioteca Digital">Biblioteca Digital</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Archivo</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://archivo.rae.es/">Fondo institucional</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://archivo.rae.es/index.php/coleccion-de-autografos-de-pedro-antonio-de-alarcon">Colección P. A. de Alarcón</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://archivo.rae.es/zorrilla/">Zorrilla</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/manuscritos-para-la-segunda-edicion-del-diccionario-de-autoridades">2.ª edición del «Diccionario de autoridades»</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://archivo.rae.es/fichero-de-hilo">Fichero de hilo</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Boletines</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://revistas.rae.es/bilrae/">BILRAE</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://revistas.rae.es/brae">BRAE</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span title="Recursos académicos de apoyo para el lenguaje claro">Lenguaje claro</span>
+          </div>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Enclave</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://enclavedeciencia.rae.es/inicio">Enclave de Ciencia</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Enlaces externos</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://asines.org/">Atlas sintáctico del español</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/dhecan.html">Diccionario Histórico del Español de Canarias</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/CORLEXIN.html">Corpus Léxico de Inventarios</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://lla.unileon.es/" title="Léxico leonés actual">Léxico leonés actual</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+    
+  </ul>
+  
+
+
+        </div>
+      </div>
+
+
+    </div>
+
+  </div>
+</div>
+
+</div>
+
+  </div>
+
+      
+
+    </div>
+
+    
+
+
+  <script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script src="/sites/default/files/js/js_7hSOT9HVKxMvGlrclR4TDcqOUtAR-0e88Vkq_P_PROE.js"></script>\n<script src="/damer/js/20210406.js"></script>
+<!--[if IE]>
+<style>
+#deletex{ display:none;}
+</style>
+<![endif]-->
+</body>
+<script>
+window.cat='NOT FOUND';window.acc='ESCALONADA';window.eti='asd';
+</script>
+</html>

--- a/tests/cogs/damer_sample_htmls/ir.html
+++ b/tests/cogs/damer_sample_htmls/ir.html
@@ -1,0 +1,1358 @@
+<!DOCTYPE html>
+<html lang="es">
+<head><noscript><style>form.antibot * :not(.antibot-message) { display: none !important; }</style></noscript>
+<link rel="preload" href="/sites/default/files/css/css_2toHNXfbnPicu5GM0gX9NZ5orfKOc_JkPXeCbZqaWws.css" as="style">
+<link rel="preload" href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&amp;display=swap" as="style">
+<link rel="preload" href="https://fonts.googleapis.com/css2?family=Merriweather:wght@700&amp;display=swap" as="style">
+<link rel="preload" href="/sites/default/files/css/css_MKU0IOMhjZnRGgSeMxmlSpwNVcEMZOFPTb3EZkC-BVI.css" as="style">
+<link rel="preload" href="/sites/default/files/js/js_7hSOT9HVKxMvGlrclR4TDcqOUtAR-0e88Vkq_P_PROE.js" as="script">
+<link rel="preload" href="/damer/css/20201019.css" as="style">
+<link rel="preload" href="/damer/js/20210406.js" as="script">
+<link rel="preload" href="/themes/custom/front/assets/fonts/lato/lato-bold-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/lato/lato-regular-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/merriweather/merriweather-black-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/merriweather/merriweather-light-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/merriweather/merriweather-regular-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="canonical" href="https://www.asale.org/damer/ir"/>
+<title>ir, irse | Diccionario de americanismos | ASALE</title>
+<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="I. 1. Ho , ES , Ni , Bo , Ur. Eyacular, expulsar con rapidez y fuerza el semen. pop. 2. Ch. Experimentar alguien un orgasmo. pop. II. 1. Ho."/>
+<meta name="keywords" content="ir, definición de ir, significado de ir, irse, definición de irse, significado de irse, ASALE, RAE"/>
+<meta name="author" content="ASALE"/>
+<meta name="robots" content="index,follow"/>
+<meta name="rating" content="safe for kids"/>
+<meta name="rights" content="Asociación de Academias de la Lengua Española © Todos los derechos reservados"/>
+<meta name="author" content="ASALE">
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:site" content="\@ASALEinforma"/>
+<meta name="twitter:url" content="https://www.asale.org/damer/ir"/>
+<meta name="twitter:title" content="ir, irse | Diccionario de americanismos"/>
+<meta name="twitter:description" content="I. 1. Ho , ES , Ni , Bo , Ur. Eyacular, expulsar con rapidez y fuerza el semen. pop. 2. Ch. Experimentar alguien un orgasmo. pop. II. 1. Ho."/>
+<meta name="twitter:image" content="/damer/img/logo-asale.png"/>
+<meta name="twitter:image:alt" content="«Diccionario de americanismos»"/>
+<meta property="article:author" content="https://es-es.facebook.com/asale"/>
+<meta property="og:title" content="ir, irse | Diccionario de americanismos"/>
+<meta property="og:type" content="website"/>
+<meta property="og:site_name" content="«Diccionario de americanismos»"/>
+<meta property="og:url" content="https://www.asale.org/damer/ir"/>
+<meta property="og:description" content="I. 1. Ho , ES , Ni , Bo , Ur. Eyacular, expulsar con rapidez y fuerza el semen. pop. 2. Ch. Experimentar alguien un orgasmo. pop. II. 1. Ho."/>
+<meta property="og:locale" content="es"/>
+<meta property="og:image" content="/damer/img/logo-asale.png"/>
+<meta property="og:image:type" content="image/png"/>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<link rel="shortcut icon" href="/themes/custom/front/favicon.ico" />
+<link rel="mask-icon" href="/themes/custom/front/src/assets/images/favicons/safari-pinned-tab.svg" />
+<link rel="icon" sizes="16x16" href="/themes/custom/front/src/assets/images/favicons/favicon-16x16.png" />
+<link rel="icon" sizes="32x32" href="/themes/custom/front/src/assets/images/favicons/favicon-32x32.png" />
+<link rel="apple-touch-icon" sizes="180x180" href="/themes/custom/front/src/assets/images/favicons/apple-touch-icon.png" />
+<link rel="apple-touch-icon-precomposed" sizes="180x180" href="/themes/custom/front/src/assets/images/favicons/apple-touch-icon.png" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=2, minimum-scale=1, user-scalable=yes" />
+<!--[if lt IE 9]><script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+<script type="application/ld+json">
+[{"@context": "http://schema.org/"},{"@type": ["DefinedTermSet","Book"],"@id": "https://www.asale.org/damer","name": "Diccionario de americanismos RAE - ASALE","image": "https://www.asale.org/damer/img/logo-asale.png","description": "Versión electrónica del «Diccionario de americanismos»."},{"@type": "DefinedTerm","@id": "https://www.asale.org/damer/ir","name": "ir","description": "I. 1. Ho , ES , Ni , Bo , Ur. Eyacular, expulsar con rapidez y fuerza el semen. pop. 2. Ch. Experimentar alguien un orgasmo. pop. II. 1. Ho.","inDefinedTermSet": "https://www.asale.org/damer"}]
+</script><link rel="stylesheet" media="all" href="/sites/default/files/css/css_2toHNXfbnPicu5GM0gX9NZ5orfKOc_JkPXeCbZqaWws.css"/>
+<link rel="stylesheet" media="all" href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&amp;display=swap"/>
+<link rel="stylesheet" media="all" href="https://fonts.googleapis.com/css2?family=Merriweather:wght@700&amp;display=swap"/>
+<link rel="stylesheet" media="all" href="/sites/default/files/css/css_MKU0IOMhjZnRGgSeMxmlSpwNVcEMZOFPTb3EZkC-BVI.css"/>
+<script>window.a2a_config=window.a2a_config||{};a2a_config.callbacks=[];a2a_config.overlays=[];a2a_config.templates={};a2a_config.static_server= "http://www.asale.org/sites/default/files/addtoany/menu/oafg07ee";a2a_config.icon_color = "transparent,#000";</script>
+
+<link rel="stylesheet" media="all" href="/damer/css/20201019.css"/>
+</head>
+<body class="path--node body-sidebars-none alias--noticia-primera-reunion-plenaria-virtual-de-directores-y-presidentes-de-las-academias-de-la-lengua nodetype--noticia logged-out" data-aos-easing="ease" data-aos-duration="400" data-aos-delay="0">
+<div role="main">
+<div class="dialog-off-canvas-main-canvas" data-off-canvas-main-canvas="">
+<div class="page-standard" id="pg__c">
+
+<header id="header" class="header">
+
+  <div class="header__logo">
+    <div class="img">
+                <a href="/" title="Inicio - ASALE" rel="home" class="site-logo">
+            <img src="/themes/custom/asale/assets/images/logo-asale.png" alt="Logo ASALE"/>
+          </a>
+          </div>
+  </div>
+
+  <div class="header-menu-search">
+
+    <nav class="header-menu">
+
+      <div class="main-menu-container">
+        <span class="menu-buttom__close">
+  <svg class="icon icon--xsmall icon-black">
+    <title>cerrar</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#close"></use>
+  </svg>
+</span>
+        
+
+<nav role="navigation" aria-labelledby="block-navegacionprincipalasale" id="block-navegacionprincipalasale" class="block block-menu navigation block-system-menublock menu--main-asale">
+      
+        
+
+
+              <ul class="menu-list main">
+              <li class="menu-list__item" >
+
+                  <div class="parent-item">
+            <a href="/la-asociacion" data-drupal-link-system-path="node/29051">La Asociación</a>
+            <span class="menu-collapse">
+              <svg class="icon icon--xsmall icon-black">
+                <title>Abrir submenu</title>
+                <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-bottom"></use>
+              </svg>
+            </span>
+          </div>
+        
+
+                                <ul>
+              <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/bienvenida" data-drupal-link-system-path="node/31480">Bienvenida</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/presentacion" data-drupal-link-system-path="node/31494">Presentación</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/comision-permanente" data-drupal-link-system-path="node/29478">Comisión Permanente</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/politica-panhispanica" data-drupal-link-system-path="node/31648">Política panhispánica</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/actividad-institucional" data-drupal-link-system-path="node/31515">Actividad institucional</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/biblioteca-de-la-asale" data-drupal-link-system-path="node/31634">Biblioteca de la ASALE</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/conmemoraciones" data-drupal-link-system-path="node/31641">Conmemoraciones</a>
+        
+
+              </li>
+      </ul>
+    
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/academias" data-drupal-link-system-path="academias">Academias</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <div class="parent-item">
+            <a href="/obras" data-drupal-link-system-path="node/29030">Obras</a>
+            <span class="menu-collapse">
+              <svg class="icon icon--xsmall icon-black">
+                <title>Abrir submenu</title>
+                <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-bottom"></use>
+              </svg>
+            </span>
+          </div>
+        
+
+                                <ul>
+              <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/diccionarios" data-drupal-link-system-path="taxonomy/term/100">Diccionarios</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/gramatica" data-drupal-link-system-path="taxonomy/term/101">Gramática</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/ortografia" data-drupal-link-system-path="taxonomy/term/102">Ortografía</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/ediciones-conmemorativas" data-drupal-link-system-path="taxonomy/term/103">Ediciones conmemorativas</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/clasicos-asale" data-drupal-link-system-path="taxonomy/term/337">Clásicos ASALE</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/otras-obras" data-drupal-link-system-path="taxonomy/term/330">Otras obras</a>
+        
+
+              </li>
+      </ul>
+    
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/corpus" data-drupal-link-system-path="node/29037">Corpus</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <div class="parent-item">
+            <a href="/escuela-de-lexicografia" data-drupal-link-system-path="node/29044">Escuela de Lexicografía</a>
+            <span class="menu-collapse">
+              <svg class="icon icon--xsmall icon-black">
+                <title>Abrir submenu</title>
+                <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-bottom"></use>
+              </svg>
+            </span>
+          </div>
+        
+
+                                <ul>
+              <li class="menu-list__item" >
+
+                  <a href="/escuela-de-lexicografia/la-elh" data-drupal-link-system-path="node/32131">La ELH</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/escuela-de-lexicografia/master-de-lexicografia-hispanica-y-correccion-linguistica" data-drupal-link-system-path="node/88530">Máster</a>
+        
+
+              </li>
+      </ul>
+    
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/publicaciones" data-drupal-link-system-path="node/28988">Publicaciones</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/noticias" data-drupal-link-system-path="noticias">Noticias</a>
+        
+
+              </li>
+      </ul>
+    
+
+
+  </nav>
+      </div>
+
+      <ul class="search-block">
+        <li class="menu-list__item link-dle">
+          <svg class="icon icon--tiny icon-white">
+            <title>Recursos</title>
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#diccionarios"></use>
+          </svg>
+          <span class="menu-list__text">Recursos</span>
+        </li>
+        <li class="menu-list__item link-search">
+          <svg class="icon icon--xsmall icon-white">
+            <title>Buscador</title>
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#lupa"></use>
+          </svg>
+        </li>
+        <li class="menu-list__item link-menu">
+          <svg class="icon icon--small icon-white">
+            <title>Menu</title>
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#menu"></use>
+          </svg>
+        </li>
+      </ul>
+
+    </nav>
+  </div>
+</header>
+<div class="container">
+<div class="row">
+<div class="col-xs-12 col-md-8" style="border-right:1px solid #ccc">  
+<div style="margin: 20px 0 10px 0;font-size:2em"><a href="/damer/">Diccionario de americanismos</a></div>
+<div class="form-box-wrapper">
+<div class="form-box"><form action="#" method="post" class="form form-damer" id="formulario"><input size="30" style="border:1px solid #ccc" class="custom-search-box" name="w" id="wq" type="text" value="" placeholder="Escriba aquí la palabra" autocomplete="off" autocapitalize="off"/><input style="margin-left:5px" alt="Buscar" type="image" class="icon icon--xsmall icon-grey" src="/themes/custom/front/src/assets/images/lupa.svg" name="submit"></form></div>
+<div class="addtext"><a style="" href="javascript:addText('á','damer');">á</a><a style="" href="javascript:addText('é','damer');">é</a><a style="" href="javascript:addText('í','damer');">í</a><a style="" href="javascript:addText('ó','damer');">ó</a><a style="" href="javascript:addText('ú','damer');">ú</a><a style="" href="javascript:addText('ü','damer');">ü</a><a style="" href="javascript:addText('ñ','damer');">ñ</a></div>
+</div>
+
+<div class="bloque-txt" id="resultados">
+<entry xmlns="http://www.w3.org/1999/xhtml" header="ir" key="ir|irse" id="xPONAkEBWx0AqRqE9MM" origHeader="ir(se)">
+<table class="da4"><tr><td colspan="5" class="da2"><span class="da8">ir(se). </span></td></tr><tr><td> </td><td class="da7"><span class="da3">I.</span></td><td class="da7"><span class="da3">1.</span></td><td colspan="2" class="da6">intr. prnl. <i><span class="da5">Ho</span></i><span class="da5">, </span><i><span class="da5">ES</span></i><span class="da5">, </span><i><span class="da5">Ni</span></i><span class="da5">, </span><i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ur.</span></i><span class="da5"> Eyacular, expulsar con rapidez y fuerza el semen. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">2.</span></td><td valign="top" colspan="2"><i><span class="da5">Ch.</span></i><span class="da5"> Experimentar </span><i><span class="da5">alguien</span></i><span class="da5"> un orgasmo. pop.</span></td></tr><tr><td> </td><td class="da7"><span class="da3">II.</span></td><td class="da7"><span class="da3">1.</span></td><td colspan="2" class="da6">intr. <i><span class="da5">Ho.</span></i><span class="da5"> Ser, estar.</span></td></tr><tr><td> </td><td class="da7"><span class="da3">&#x25CF;</span></td><td> </td><td> </td><td> </td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">a. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xA1;c&#xF3;mo va a ser!</span><span class="da5"> f&#xF3;rm. </span><i><span class="da5">CR</span></i><span class="da5">, </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">PR</span></i><span class="da5">, </span><i><span class="da5">Co.</span></i><span class="da5"> Se usa para expresar simult&#xE1;neamente preocupaci&#xF3;n, sorpresa y conmiseraci&#xF3;n. </span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">b. &#x1C1; </span></td><td colspan="2"><span class="da3">va cayendo gente al baile.</span><span class="da5"> f&#xF3;rm. </span><i><span class="da5">Ar</span></i><span class="da5">, </span><i><span class="da5">Ur.</span></i><span class="da5"> Se usa para anunciar o celebrar la llegada de alguien, </span><i><span class="da5">especialmente a una reuni&#xF3;n</span></i><span class="da5">. pop + cult &#x2192; espon ^ fest.</span><span class="da5"> &#x25C6; </span><span class="da3">va llegando gente al baile</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">c. &#x1C1; </span></td><td colspan="2"><span class="da3"> va llegando gente al baile.</span> <i><span class="da5">Cu.</span></i> <span class="da3">va cayendo gente al baile</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">d. &#x1C1; </span></td><td colspan="2"><span class="da3">vaya alante que la luz es verde.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">f&#xF3;rm. </span><i><span class="da5">Pa.</span></i><span class="da5"> juv. Se usa para expresar incomodidad por la presencia de alguien en un grupo.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Pa.</span></i><span class="da5"> juv. Se usa para indicar a alguien que contin&#xFA;e la tarea que est&#xE1; realizando.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">e. &#x1C1; </span></td><td colspan="2"><span class="da3">y va que jode.</span><span class="da5"> f&#xF3;rm. </span><i><span class="da5">Cu.</span></i><span class="da5"> Se usa para indicar que una persona debe darse por satisfecha con algo determinado que ha obtenido o que se le ofrece.</span></td></tr><tr><td> </td><td class="da7"><span class="da3">&#x25A1;</span></td><td> </td><td> </td><td> </td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">a. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> a amarrar un conejo.</span><span class="da5"> loc. verb. </span><i><span class="da5">ES.</span></i><span class="da5"> Defecar en el monte. rur; fest.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">b. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> a Chicago.</span><span class="da5"> loc. verb. </span><i><span class="da5">Bo.</span></i><span class="da5"> Ir a evacuar el vientre. pop + cult &#x2192; espon ^ fest.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">c. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> a comer rancho.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> Ir a la c&#xE1;rcel. rur.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">d. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> a comerse un pollito al velador.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ch.</span></i><span class="da5"> Ir </span><i><span class="da5">alguien</span></i><span class="da5"> a un </span><a href='motel'>motel</a><span class="da5"> a la hora de almuerzo. pop + cult &#x2192; espon ^ fest.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">e. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> a donde el rey va solo.</span><span class="da5"> loc. verb. </span><i><span class="da5">Mx.</span></i><span class="da5"> Dirigirse al ba&#xF1;o o a otro lugar con la intenci&#xF3;n de orinar o defecar. euf.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">f. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> a la mata.</span><span class="da5"> loc. verb. </span><i><span class="da5">RD.</span></i><span class="da5"> Ir a evacuar el vientre. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">g. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> a la mesa.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> Ir </span><i><span class="da5">alguien</span></i><span class="da5"> a un lugar cualquiera a planear un robo. delinc.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">h. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> a las casitas.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ch.</span></i><span class="da5"> Ir </span><i><span class="da5">alguien</span></i><span class="da5"> al excusado. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">i. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> a las millas de chafl&#xE1;n.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> Conducir un veh&#xED;culo de motor a gran velocidad.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">j. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> a lo seguro.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ec.</span></i><span class="da5"> Optar por el camino m&#xE1;s f&#xE1;cil y sencillo </span><span class="da0">para resolver una situaci&#xF3;n.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">k. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> a los bifes.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Ar</span></i><span class="da5">, </span><i><span class="da5">Ur.</span></i><span class="da5"> Enfrentarse con decisi&#xF3;n a una situaci&#xF3;n o dificultad. pop.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Ur.</span></i><span class="da5"> Agredir f&#xED;sicamente a </span><i><span class="da5">alguien</span></i><span class="da5">. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">iii.</span></td> <td><i><span class="da5">Ur.</span></i> <i><span class="da5">En una relaci&#xF3;n amorosa</span></i><span class="da5">, buscar un acercamiento f&#xED;sico. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">l. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> a m&#xE1;ster.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ve.</span></i><span class="da5"> Ir </span><i><span class="da5">alguien</span></i><span class="da5"> al excusado. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">m. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> a merco.</span><span class="da5"> loc. verb. </span><i><span class="da5">Bo:O.</span></i><span class="da5"> Tomar </span><i><span class="da5">una persona</span></i><span class="da5"> alimentos s&#xF3;lidos. delinc.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">n. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> a mi arbolito.</span><span class="da5"> loc. verb. </span><i><span class="da5">Mx.</span></i><span class="da5"> Dirigirse al ba&#xF1;o o a otro lugar con la intenci&#xF3;n de orinar. euf.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">&#xF1;. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> a parar las patas.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ni.</span></i><span class="da5"> Caerse o golpearse </span><i><span class="da5">alguien</span></i><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">o. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> a templar.</span><span class="da5"> loc. verb. </span><i><span class="da5">Co:C.</span></i><span class="da5"> Terminar o desembocar en algo.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">p. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> a tener.</span><span class="da5"> loc. verb. </span><i><span class="da5">RD.</span></i><span class="da5"> Ir a parar o desembocar. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">q. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> a toda.</span><span class="da5"> loc. verb. </span><i><span class="da5">Co.</span></i><span class="da5"> Ir a gran velocidad. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">r. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> a todas las paradas.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ch.</span></i><span class="da5"> Participar con entusiasmo en todo tipo de actividades. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">s. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> a un entierro.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Ni</span></i><span class="da5">, </span><i><span class="da5">Bo.</span></i><span class="da5"> Buscar una relaci&#xF3;n sexual clandestina.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">ES.</span></i><span class="da5"> Acudir a una cita amorosa. sat.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">t. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> adentro.</span><span class="da5"> loc. verb. </span><i><span class="da5">ES.</span></i><span class="da5"> Ir al servicio. euf.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">u. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> afuera.</span><span class="da5"> loc. verb. </span><i><span class="da5">ES</span></i><span class="da5">, </span><i><span class="da5">Ni</span></i><span class="da5">, </span><i><span class="da5">RD.</span></i><span class="da5"> Defecar. rur.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">v. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> al bombo.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Ar.</span></i><span class="da5"> No apoyar </span><i><span class="da5">una persona</span></i><span class="da5"> una iniciativa o ir contra ella. pop.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Ar.</span></i> <i><span class="da5">En el deporte, </span></i><i><span class="da0">especialmente en el </span></i><i><span class="da9">futbol</span></i><span class="da5">, no esforzarse por ganar un equipo, </span><i><span class="da0">en general por haber aceptado un soborno</span></i><span class="da5">. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">w. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> al chauchau.</span><span class="da5"> loc. verb. </span><i><span class="da5">RD.</span></i><span class="da5"> Ir a comer. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">x. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> al despulpe.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> Trabajar </span><i><span class="da5">alguien</span></i><span class="da5"> en la limpieza del caf&#xE9; uva, </span><span class="da0">quit&#xE1;ndole la corteza exterior, mediante los procedimientos del lavado</span><span class="da5">. rur.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">y. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> al jal&#xF3;n.</span><span class="da5"> loc. verb. </span><i><span class="da5">ES</span></i><span class="da5">, </span><i><span class="da5">CR.</span></i><span class="da5"> Transportar a </span><i><span class="da5">alguien</span></i><span class="da5"> como pasajero de manera gratuita.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">z. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> al muere.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ar</span></i><span class="da5">, </span><i><span class="da5">Ur.</span></i><span class="da5"> Emprender una tarea peligrosa, muy dif&#xED;cil o que supone un fracaso seguro. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">a<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> al punto.</span><span class="da5"> loc. verb. </span><i><span class="da5">Bo.</span></i><span class="da5"> Hablar </span><i><span class="da5">alguien</span></i><span class="da5"> sin rodeos sobre un tema. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">b<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> al seguro.</span><span class="da5"> loc. verb. </span><i><span class="da5">Cu.</span></i><span class="da5"> Realizar una tarea con la certeza de que no habr&#xE1; equivocaciones.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">c<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> al suave.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ho</span></i><span class="da5">, </span><i><span class="da5">ES</span></i><span class="da5">, </span><i><span class="da5">Ni.</span></i><span class="da5"> Caminar o hacer </span><i><span class="da5">algo</span></i><span class="da5"> muy despacio.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">d<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> al zoco.</span><span class="da5"> loc. verb. </span><i><span class="da5">Co:O.</span></i><span class="da5"> Caminar, correr o desplazarse de forma muy apresurada. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">e<sup>1</sup>. &#x1C1;</span></td> <td colspan="2"><span class="da0">~</span><span class="da3"> arreado.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ni</span></i><span class="da5">, </span><i><span class="da5">Co.</span></i><span class="da5"> Ir muy deprisa. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">f<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> bajando.</span><span class="da5"> loc. verb. </span><i><span class="da5">Pa</span></i><span class="da5">, </span><i><span class="da5">RD.</span></i><span class="da5"> Marcharse. </span><span class="da5">&#x25C6;</span><span class="da5"> </span><span class="da3">ir por fuera</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">g<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> bien pisado.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ho.</span></i><span class="da5"> Tener suspensa o reprobada una asignatura.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">h<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span> <i><a href='bumper'>bumper</a></i><span class="da3"> con </span><i><a href='bumper'>bumper</a></i><span class="da3">.</span> <span class="da1">(Del</span> <span class="da1">ingl.</span> <i><span class="da1">bumper</span></i><span class="da1">, defensa, parachoque).</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">PR.</span></i> <i><span class="da5">En un atasco</span></i><span class="da5">, ir muy pegado al autom&#xF3;vil de otro. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">PR.</span></i> <i><span class="da5">En una aglomeraci&#xF3;n de personas</span></i><span class="da5">, ir muy pegadas. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">i<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> como ca&#xF1;a pa'lpal ingenio.</span> </td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">j<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> como carreta en bajada.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ni.</span></i><span class="da5"> Hacer algo apresuradamente.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">RD.</span></i><span class="da5"> Ir deprisa y corriendo.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">RD.</span></i><span class="da5"> Llevar, conducir, guiar de forma d&#xF3;cil a </span><i><span class="da5">alguien</span></i><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">k<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> como congo de hoya.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> Dar tumbos un borracho al caminar. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">l<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> como perro de rico.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> Ir </span><i><span class="da5">alguien</span></i><span class="da5"> muy bien, sin que le falte nada. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">m<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> con el chisme.</span><span class="da5"> loc. verb. </span><i><span class="da5">Mx</span></i><span class="da5">, </span><i><span class="da5">ES</span></i><span class="da5">, </span><i><span class="da5">Ni</span></i><span class="da5">, </span><i><span class="da5">Cu</span></i><span class="da5">, </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">Ec</span></i><span class="da5">, </span><i><span class="da5">Pe</span></i><span class="da5">, </span><i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ar.</span></i><span class="da5"> Decirle </span><i><span class="da5">algo</span></i><span class="da5"> a </span><i><span class="da5">alguien</span></i> <span class="da0">para perjudicar a otra persona o ponerla en dificultades</span><span class="da5">. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">n<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> con el pito y la caja.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ho.</span></i><span class="da5"> Chismorrear. pop ^ fest.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">&#xF1;<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> con la embajada.</span><span class="da5"> loc. verb. </span><i><span class="da5">RD.</span></i><span class="da5"> Ir a contar un secreto o un chisme a una tercera persona. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">o<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> con la oreja par&#xE1;.</span><span class="da5"> loc. verb. </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">PR.</span></i><span class="da5"> Tomar precauciones. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3"> p<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> con nando.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ni.</span></i><span class="da5"> Caminar, ir a pie. fest.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">q<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> con sus buenos bujillazos.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ni.</span></i><span class="da5"> Estar borracho.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">r<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> de alero en alero.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ho.</span></i><span class="da5"> Andar </span><i><span class="da5">alguien</span></i><span class="da5"> de un lugar a otro.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">s<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> de ca&#xED;.</span><span class="da5"> loc. verb. </span><i><span class="da5">Py.</span></i><span class="da5"> Viajar sin pagar boleto.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">t<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> de ca&#xF1;&#xF3;n.</span><span class="da5"> loc. verb. </span><i><span class="da5">Pa.</span></i><span class="da5"> Asistir con toda seguridad a una cita o a un acto.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">u<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> de cuete.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ho.</span></i><span class="da5"> Huir o salir velozmente.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">v<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> de hal&#xF3;n.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ho.</span></i><span class="da5"> Hacer autoestop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">w<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> de paquete.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> obsol. Ir muy elegante. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">x<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> de pasada.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ho.</span></i><span class="da5"> Tener mucha prisa.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">y<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> de pato.</span><span class="da5"> loc. verb. </span><i><span class="da5">Co.</span></i><span class="da5"> Asistir a una fiesta o a una reuni&#xF3;n sin haber sido invitado. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">z<sup>1</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> de </span><i><span class="da3">pinch hitter</span></i><span class="da3">.</span> <span class="da1">(Del</span> <span class="da1">ingl.</span> <i><span class="da1">pinch hitter</span></i><span class="da1">).</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> Ir </span><i><span class="da5">alguien</span></i><span class="da5"> de acompa&#xF1;ante de otro, </span><span class="da0">como refuerzo.</span><span class="da5"> pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">PR.</span></i><span class="da5"> Ir </span><i><span class="da5">alguien</span></i><span class="da5"> en sustituci&#xF3;n de otro. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">a<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> de rabo.</span> <i><span class="da5">CR.</span></i> <span class="da3">andar de rabo</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">b<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> de rumba.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR</span></i><span class="da5">, </span><i><span class="da5">Co.</span></i><span class="da5"> Salir con amigos a divertirse.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">c<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> de verdugo.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ho:N.</span></i><span class="da5"> Estar en actitud permanente de enamorar.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">d<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> del tingo al tango.</span><span class="da5"> loc. verb. </span><i><span class="da5">Mx</span></i><span class="da5">, </span><i><span class="da5">Gu</span></i><span class="da5">, </span><i><span class="da5">ES</span></i><span class="da5">, </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">PR</span></i><span class="da5">, </span><i><span class="da5">Co.</span></i><span class="da5"> Ir </span><i><span class="da5">alguien</span></i><span class="da5"> de una parte a otra, de aqu&#xED; para all&#xED;. pop + cult &#x2192; espon.</span><span class="da5"> &#x25C6; </span><span class="da3">ir del tingo al tango y del tango al tingo</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">e<sup>2</sup>. &#x1C1;</span></td> <td colspan="2"><span class="da0">~</span><span class="da3"> del tingo al tango y del tango al tingo.</span> <i><span class="da5">PR.</span></i> <span class="da3">ir del tingo al tango</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">f<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> echando.</span><span class="da5"> loc. verb. </span><i><span class="da5">Cu.</span></i><span class="da5"> Marcharse de un lugar.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">g<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> embollado.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> Ir r&#xE1;pidamente, ir deprisa.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">h<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> en caballo de hacienda.</span><span class="da5"> loc. verb. </span><i><span class="da5">Mx.</span></i> <i><span class="da5">En una rivalidad o competencia</span></i><span class="da5">, progresar </span><i><span class="da5">alguien</span></i><span class="da5"> con autoridad y clara ventaja sobre los dem&#xE1;s participantes hacia la consecuci&#xF3;n del triunfo. (</span><span class="da3">cabalgar en caballo de hacienda</span><span class="da5">).</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">i<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> en coche.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Co</span></i><span class="da5">, </span><i><span class="da5">Ur.</span></i><span class="da5"> Facilit&#xE1;rsele a </span><i><span class="da5">alguien</span></i><span class="da5"> hacer las cosas </span><span class="da0">por contar con ayuda o los medios necesarios.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">PR.</span></i><span class="da5"> Conceder </span><i><span class="da5">algo</span></i><span class="da5"> con reservas. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">iii.</span></td> <td><i><span class="da5">Cu.</span></i><span class="da5"> Terminar un asunto mejor de lo que esperaba. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">j<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> en </span><i><a href='high'>high</a></i><span class="da3">.</span> <span class="da1">(Del</span> <span class="da1">ingl.</span> <i><span class="da1">high</span></i><span class="da1">).</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> Caminar borracho. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">PR.</span></i><span class="da5"> Ir a toda velocidad.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">k<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> en pira.</span><span class="da5"> loc. verb. </span><i><span class="da5">Cu.</span></i><span class="da5"> Marcharse r&#xE1;pidamente de un lugar. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">l<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> en punta.</span><span class="da5"> loc. verb. </span><i><span class="da5">ES</span></i><span class="da5">, </span><i><span class="da5">Cu</span></i><span class="da5">, </span><i><span class="da5">PR</span></i><span class="da5">, </span><i><span class="da5">Co</span></i><span class="da5">, </span><i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ar.</span></i><span class="da5"> Ir en la delantera en una carrera o competici&#xF3;n. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3"> m<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> escapando.</span><span class="da5"> loc. verb. </span><i><span class="da5">Cu.</span></i><span class="da5"> Subsistir con pocos recursos econ&#xF3;micos. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">n<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> guindo abajo.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ho.</span></i><span class="da5"> Caerse por un precipicio o una pendiente.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">&#xF1;<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> hecho un culo.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ho</span></i><span class="da5">, </span><i><span class="da5">ES.</span></i><span class="da5"> Salir r&#xE1;pidamente, huir velozmente. vulg.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">o<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> hule.</span><span class="da5"> loc. verb. </span><i><span class="da5">ES.</span></i><span class="da5"> Estar vac&#xED;o un veh&#xED;culo o local.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">p<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> inyectao.</span> <i><span class="da5">PR.</span></i> <span class="da3">ir en </span><i><a href='high'>high</a></i><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">q<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> mat&#xE1;ndose.</span><span class="da5"> loc. verb. </span><i><span class="da5">Mx</span></i><span class="da5">, </span><i><span class="da5">Ni</span></i><span class="da5">, </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">PR</span></i><span class="da5">, </span><i><span class="da5">Co.</span></i><span class="da5"> Marchar, moverse a gran velocidad o con prisas. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">r<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> muerto.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ch</span></i><span class="da5">, </span><i><span class="da5">Ar</span></i><span class="da5">, </span><i><span class="da5">Ur.</span></i><span class="da5"> Tener pocas posibilidades o ninguna de salir con &#xE9;xito de una situaci&#xF3;n. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">s<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> palo abajo.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ve.</span></i><span class="da5"> Deteriorarse, decaer una persona o cosa. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">t<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> para el cacharro.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> Ir a la c&#xE1;rcel. rur.</span><span class="da5"> &#x25C6; </span><span class="da3">ir para el rancho</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">u<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> para el carajo.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Ur.</span></i><span class="da5"> Desvincularse </span><i><span class="da5">alguien</span></i><span class="da5"> dr&#xE1;sticamente </span><span class="da0">por desavenencias.</span><span class="da5"> pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Ur.</span></i><span class="da5"> Tener </span><i><span class="da5">algo</span></i><span class="da5"> mal fin. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">v<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> para el rancho.</span> <i><span class="da5">PR.</span></i> <span class="da3">ir para el cacharro</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">w<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> para encima.</span><span class="da5"> loc. verb. </span><i><span class="da5">Pa.</span></i><span class="da5"> Aprovechar</span> <i><span class="da5">una persona algo</span></i><span class="da5"> o una situaci&#xF3;n.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">x<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> pelo a pelo.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i> <i><span class="da5">En una </span></i><i><a href='competencia'>competencia</a></i><i><span class="da5"> o disputa</span></i><span class="da5">, ir a la par. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">y<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> pisa(d)o.</span><span class="da5"> loc. verb. </span><i><span class="da5">Pa</span></i><span class="da5">, </span><i><span class="da5">PR.</span></i><span class="da5"> Ir deprisa.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">z<sup>2</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> pisando niguas.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> Hacer </span><i><span class="da5">algo</span></i><span class="da5"> con desgano y sin prisas. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">a<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> pita(d)o.</span><span class="da5"> loc. verb. </span><i><span class="da5">Mx</span></i><span class="da5">, </span><i><span class="da5">PR.</span></i><span class="da5"> Ir muy r&#xE1;pidamente. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">b<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> por dentro.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ho.</span></i><span class="da5"> Participar con alguien en un negocio ilegal.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">c<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> por el mandado.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ho.</span></i><span class="da5"> Conseguir f&#xE1;cilmente </span><i><span class="da5">algo</span></i><span class="da5">. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">d<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> por fuera.</span> <i><span class="da5">Pa.</span></i> <span class="da3">ir bajando</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">e<sup>3</sup>. &#x1C1;</span></td> <td colspan="2"><span class="da0">~</span><span class="da3"> por la otra acera.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">RD.</span></i><span class="da5"> Hablar de un tema diferente al que los dem&#xE1;s est&#xE1;n tratando.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">RD.</span></i><span class="da5"> Andar despistado.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">f<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> por la otra orilla.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i> <i><span class="da5">En las actividades mar&#xED;timas</span></i><span class="da5">, costear.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">g<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> prendido.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ar.</span></i><span class="da5"> Participar de los beneficios de un asunto o negocio, </span><i><span class="da0">generalmente il&#xED;citos</span></i><span class="da5">. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">h<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> que chifla.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Cu.</span></i><span class="da5"> Desplazarse, una persona o un veh&#xED;culo, a gran velocidad.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">RD.</span></i><span class="da5"> Conseguir una persona m&#xE1;s de lo que hab&#xED;a imaginado. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">i<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> que jode.</span><span class="da5"> loc. verb. </span><i><span class="da5">Cu.</span></i><span class="da5"> Trasladarse </span><i><span class="da5">alguien</span></i><span class="da5"> o </span><i><span class="da5">algo</span></i><span class="da5"> r&#xE1;pidamente.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">j<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> redondeando.</span> <span class="da1">(Calco del</span> <span class="da1">ingl.</span> <i><span class="da1">go around</span></i><span class="da1">).</span><span class="da5"> loc. verb. </span><i><span class="da5">EU.</span></i><span class="da5"> Torcer, desviar.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">k<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">la.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ar</span></i><span class="da5">, </span><i><span class="da5">Ur.</span></i><span class="da5"> Presumir </span><i><span class="da5">alguien, </span></i><i><span class="da0">especialmente de algo que no es</span></i><span class="da5">. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">l<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">le arriba o encima.</span><span class="da5"> loc. verb. </span><i><span class="da5">Cu</span></i><span class="da5">, </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">PR.</span></i><span class="da5"> Acometer </span><i><span class="da5">una persona</span></i><span class="da5"> a </span><i><span class="da5">alguien</span></i><span class="da5">, exigirle el cumplimiento de un compromiso. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3"> m<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">le como a los perros en misa.</span><span class="da5"> loc. verb. </span><i><span class="da5">Co.</span></i><span class="da5"> Acaecerle problemas y complicaciones a</span><i><span class="da5"> alguien</span></i><span class="da5"> en la realizaci&#xF3;n de algo. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">n<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">le como en feria.</span><span class="da5"> loc. verb. </span><i><span class="da5">Mx</span></i><span class="da5">, </span><i><span class="da5">ES.</span></i><span class="da5"> Irle a </span><i><span class="da5">alguien</span></i><span class="da5"> muy mal, tener fracasos, dificultades, etc. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">&#xF1;<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">le de la patada grande.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ho.</span></i><span class="da5"> Salir todo mal a </span><i><span class="da5">alguien</span></i><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">o<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">le del cocol.</span><span class="da5"> loc. verb. </span><i><span class="da5">Mx.</span></i><span class="da5"> Encontrarse </span><i><span class="da5">alguien</span></i><span class="da5"> en una situaci&#xF3;n complicada y penosa. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">p<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a coger por las guaretas.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> No fastidiar </span><i><span class="da5">una persona</span></i><span class="da5"> a</span><i><span class="da5"> alguien</span></i><span class="da5">. vulg; pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">q<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a comer gofio.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> Rechazar airadamente a la persona que importuna y molesta.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">r<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a empinar papalotes.</span><span class="da5"> loc. verb. </span><i><span class="da5">Cu.</span></i><span class="da5"> Rechazar a</span><i><span class="da5"> alguien</span></i><span class="da5"> con insolencia y desd&#xE9;n. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">s<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a fre&#xED;r monos.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ni</span></i><span class="da5">, </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">Ve</span></i><span class="da5">, </span><i><span class="da5">Pe</span></i><span class="da5">, </span><i><span class="da5">Bo.</span></i><span class="da5"> Irse </span><i><span class="da5">alguien</span></i><span class="da5"> y no molestar. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">t<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a fre&#xED;r papas.</span> <i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">PR.</span></i> <span class="da3">irse a fre&#xED;r monos</span><span class="da5">. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">u<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a fre&#xED;r tamales.</span> <i><span class="da5">Bo:E.</span></i> <span class="da3">irse a fre&#xED;r tusas</span><span class="da5">. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">v<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a fre&#xED;r tusas.</span><span class="da5"> loc. verb. </span><i><span class="da5">Cu</span></i><span class="da5">, </span><i><span class="da5">RD.</span></i><span class="da5"> Rechazar a</span><i><span class="da5"> alguien</span></i><span class="da5"> con insolencia y desd&#xE9;n. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">w<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a guardar.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> Ir a la c&#xE1;rcel. delinc.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">x<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a jurta.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> Echarse a perder </span><i><span class="da5">algo</span></i><span class="da5">, </span><i><span class="da0">especialmente una </span></i><i><span class="da9">chiringa</span></i><i><span class="da0"> o un </span></i><i><span class="da9">volant&#xED;n</span></i><span class="da5">. rur.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">y<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a justa.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> Echarse a perder un asunto o cosa. (</span><span class="da3">irse a juste</span><span class="da5">).</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">z<sup>3</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a juste.</span> <i><span class="da5">PR.</span></i> <span class="da3">irse a justa</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">a<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a la chingada.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Mx</span></i><span class="da5">, </span><i><span class="da5">Gu</span></i><span class="da5">, </span><i><span class="da5">Ni.</span></i><span class="da5"> Ser rechazada </span><i><span class="da5">una persona</span></i><span class="da5"> con enfado o disgusto. vulg.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Mx.</span></i><span class="da5"> Da&#xF1;arse o romperse </span><i><span class="da5">algo</span></i><span class="da5">. vulg.</span><span class="da5"> &#x25C6; </span><span class="da3">irse a la fregada</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">iii.</span></td> <td><i><span class="da5">Mx.</span></i><span class="da5"> Concluir </span><i><span class="da5">algo</span></i><span class="da5"> bruscamente y de mala manera. vulg.</span><span class="da5"> &#x25C6; </span><span class="da3">irse a la fregada</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">iv.</span></td> <td><i><span class="da5">Mx.</span></i><span class="da5"> Recibir </span><i><span class="da5">una persona</span></i><span class="da5"> un gran da&#xF1;o del que no podr&#xE1; recuperarse. vulg.</span><span class="da5"> &#x25C6; </span><span class="da3">irse a la fregada</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">v.</span></td> <td><i><span class="da5">Gu</span></i><span class="da5">, </span><i><span class="da5">Ni.</span></i><span class="da5"> Marcharse lejos o abandonar un lugar de forma brusca o r&#xE1;pida. vulg.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">b<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a la chingada grande.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ho</span></i><span class="da5">, </span><i><span class="da5">ES</span></i><span class="da5">, </span><i><span class="da5">Ni.</span></i><span class="da5"> Mandar a</span><i><span class="da5"> alguien</span></i><span class="da5"> lejos, a la mierda.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">c<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a la chira.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">ES.</span></i><span class="da5"> Irse a la mierda. vulg.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Ho.</span></i><span class="da5"> Ser </span><i><span class="da5">alguien</span></i><span class="da5"> encarcelado.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">d<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a la chucha.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Ch.</span></i><span class="da5"> Echarse a perder </span><i><span class="da5">algo</span></i><span class="da5">, frustrarse o acabar mal. vulg; pop.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Ch.</span></i><span class="da5"> Rechazar </span><i><span class="da5">algo</span></i><span class="da5"> o a </span><i><span class="da5">alguien</span></i><span class="da5"> que provoca enfado o impaciencia. vulg; pop ^ desp.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">e<sup>4</sup>. &#x1C1;</span></td> <td colspan="2"><span class="da0">~</span><span class="da3">se a la cresta.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ch.</span></i><span class="da5"> Rechazar </span><i><span class="da5">algo</span></i><span class="da5"> o a </span><i><span class="da5">alguien</span></i><span class="da5"> que provoca enfado o impaciencia. vulg; pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">f<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a la droga.</span><span class="da5"> loc. verb. </span><i><span class="da5">Gu</span></i><span class="da5">, </span><i><span class="da5">Ho</span></i><span class="da5">, </span><i><span class="da5">ES.</span></i><span class="da5"> Marcharse lejos. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">g<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a la fija.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ni</span></i><span class="da5">, </span><i><span class="da5">Co</span></i><span class="da5">, </span><i><span class="da5">Bo.</span></i><span class="da5"> Estar </span><i><span class="da5">alguien</span></i><span class="da5"> seguro de algo o en algo.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">h<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a la fregada.</span> <i><span class="da5">Mx.</span></i> <span class="da3">irse a la chingada</span><span class="da5">. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">i<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a la goma.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Mx.</span></i><span class="da5"> Deteriorarse </span><i><span class="da5">algo</span></i><span class="da5">. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Mx.</span></i><span class="da5"> Deshacerse o desentenderse de alguien o algo. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">j<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a la lona.</span><span class="da5"> loc. verb. </span><i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ar</span></i><span class="da5">, </span><i><span class="da5">Ur.</span></i><span class="da5"> Abandonar la lucha, darse por vencido. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">k<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a la punta.</span><span class="da5"> loc. verb. </span><i><span class="da5">Gu.</span></i><span class="da5"> Marcharse lejos. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">l<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a la punta de un cuerno.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ec.</span></i><span class="da5"> Arruinarse, fracasar </span><i><span class="da5">algo </span></i><span class="da5">o</span><i><span class="da5"> alguien</span></i><span class="da5">. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">m<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a la verga.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ho.</span></i><span class="da5"> Marcharse </span><i><span class="da5">una persona</span></i><span class="da5"> lejos. vulg.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">n<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a las gre&#xF1;as.</span><span class="da5"> loc. verb. </span><i><span class="da5">Mx</span></i><span class="da5">, </span><i><span class="da5">Ni</span></i><span class="da5">, </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">Bo.</span></i><span class="da5"> Re&#xF1;ir </span><i><span class="da5">dos personas,</span></i><span class="da5"> a veces tir&#xE1;ndose de los cabellos. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">&#xF1;<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a las pailas.</span><span class="da5"> loc. verb. </span><i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ch.</span></i><span class="da5"> Fracasar, arruinarse, frustrarse </span><i><span class="da5">algo</span></i><span class="da5">. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">o<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a los golpes.</span><span class="da5"> loc. verb. </span><i><span class="da5">Mx</span></i><span class="da5">, </span><i><span class="da5">Ni</span></i><span class="da5">, </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">PR</span></i><span class="da5">, </span><i><span class="da5">Co</span></i><span class="da5">, </span><i><span class="da5">Ec</span></i><span class="da5">, </span><i><span class="da5">Pe</span></i><span class="da5">, </span><i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ch.</span></i><span class="da5"> Pelearse dos personas golpe&#xE1;ndose entre s&#xED;.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">p<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a negro.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Ch.</span></i><span class="da5"> Apagarse o fundirse </span><i><span class="da5">algo</span></i><span class="da5">, </span><i><span class="da0">especialmente una pantalla</span></i><span class="da5">. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Ch.</span></i><span class="da5"> Perder </span><i><span class="da5">alguien</span></i><span class="da5"> temporalmente la conciencia o la capacidad de reacci&#xF3;n.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">q<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a poza azul.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ni.</span></i><span class="da5"> Huir con rapidez, desaparecer </span><i><span class="da5">alguien</span></i><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">r<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se a volver.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ec.</span></i><span class="da5"> Ausentarse </span><i><span class="da5">alguien</span></i><span class="da5"> por un breve espacio de tiempo. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">s<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se al bollo.</span><span class="da5"> loc. verb. </span><i><span class="da5">RD.</span></i><span class="da5"> Ser abandonada o menospreciada </span><i><span class="da5">una persona</span></i><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">t<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se al bombo.</span><span class="da5"> loc. verb. </span><i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ar</span></i><span class="da5">, </span><i><span class="da5">Ur.</span></i><span class="da5"> Fracasar </span><i><span class="da5">una persona</span></i><span class="da5">, un proyecto o empresa. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">u<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se al bulto.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Ar</span></i><span class="da5">, </span><i><span class="da5">Ur.</span></i><span class="da5"> Atacar </span><i><span class="da5">una persona</span></i><span class="da5"> a otra, </span><i><span class="da0">generalmente en un momento de c&#xF3;lera y sin reflexionar</span></i><span class="da5">. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Ur.</span></i><span class="da5"> Hacer </span><i><span class="da5">algo</span></i><span class="da5"> con precipitaci&#xF3;n e irreflexivamente. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">v<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se al cachimbo.</span><span class="da5"> loc. verb. </span><i><span class="da5">RD.</span></i><span class="da5"> Frustrarse </span><i><span class="da5">algo</span></i><span class="da5">, no llegar al t&#xE9;rmino deseado. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">w<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se al chancho.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ch.</span></i><span class="da5"> Sobrepasar </span><i><span class="da5">algo</span></i><span class="da5"> o </span><i><span class="da5">alguien</span></i><span class="da5"> el l&#xED;mite de una cosa. pop + cult &#x2192; espon.</span><span class="da5"> &#x25C6; </span><span class="da3">irse al porcino</span><span class="da5">; </span><span class="da3">irse al </span><i><span class="da3">pork</span></i><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">x<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se al chicote.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ho.</span></i><span class="da5"> Marcharse lejos, huir. rur.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">y<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se al chorizo.</span><span class="da5"> loc. verb. </span><i><span class="da5">Co.</span></i><span class="da5"> Rechazar bruscamente a</span><i><span class="da5"> alguien</span></i><span class="da5"> o desentenderse de algo. pop ^ desp.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">z<sup>4</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se al hoyo.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Gu</span></i><span class="da5">, </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ch</span></i><span class="da5">, </span><i><span class="da5">Ar</span></i><span class="da5">, </span><i><span class="da5">Ur.</span></i><span class="da5"> p.u. Arruinarse econ&#xF3;micamente. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ch.</span></i><span class="da5"> Frustrarse, fracasar </span><i><span class="da5">algo</span></i><span class="da5">. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">a<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se al humo.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ar</span></i><span class="da5">, </span><i><span class="da5">Ur.</span></i><span class="da5"> Dirigirse r&#xE1;pida y decididamente a </span><i><span class="da5">una persona</span></i><span class="da5">, </span><i><span class="da0">generalmente para agredirla</span></i><span class="da5">. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">b<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se al mazo.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Ar</span></i><span class="da5">, </span><i><span class="da5">Ur.</span></i><span class="da5"> Poner las cartas propias junto al mazo en se&#xF1;al de que se abandona el juego. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Ar</span></i><span class="da5">, </span><i><span class="da5">Ur.</span></i><span class="da5"> Desistir de un empe&#xF1;o o prop&#xF3;sito, </span><i><span class="da0">especialmente para evitar riesgos o inconvenientes</span></i><span class="da5">. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">c<sup>5</sup>. &#x1C1;</span></td> <td colspan="2"><span class="da0">~</span><span class="da3">se al monte.</span><span class="da5"> loc. verb. </span><i><span class="da5">Co.</span></i><span class="da5"> Unirse a la guerrilla. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">d<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">irse al porcino.</span> <i><span class="da5">Ch.</span></i> <span class="da3">irse al chancho</span><span class="da5">. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">e<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> al </span><i><span class="da3">pork</span></i><span class="da3">.</span> <i><span class="da5">Ch.</span></i><span class="da5"> juv. </span><span class="da3">irse al chancho</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">f<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se al sipote.</span><span class="da5"> loc. verb. </span><i><span class="da5">RD.</span></i><span class="da5"> Frustrarse </span><i><span class="da5">algo</span></i><span class="da5">, no llegar al t&#xE9;rmino deseado. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">g<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se al suelo.</span><span class="da5"> loc. verb. </span><i><span class="da5">Pa.</span></i><span class="da5"> Caer, arruinarse </span><i><span class="da5">algo</span></i><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">h<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se al tacho.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ch</span></i><span class="da5">, </span><i><span class="da5">Py</span></i><span class="da5">, </span><i><span class="da5">Ar</span></i><span class="da5">, </span><i><span class="da5">Ur.</span></i><span class="da5"> Fracasar una persona, un proyecto o empresa. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ar</span></i><span class="da5">, </span><i><span class="da5">Ur.</span></i><span class="da5"> Morir </span><i><span class="da5">una persona</span></i><span class="da5">. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">i<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se andando bajito.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> Irse </span><i><span class="da5">alguien</span></i><span class="da5"> frustrado, decepcionado. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">PR.</span></i><span class="da5"> Irse </span><i><span class="da5">alguien</span></i><span class="da5"> andando despacio. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">j<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se arriba.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ni.</span></i><span class="da5"> Enga&#xF1;ar, estafar a </span><i><span class="da5">alguien</span></i><span class="da5">. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">k<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se cantando bajito.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">PR</span></i><span class="da5">, </span><i><span class="da5">Ar.</span></i><span class="da5"> Irse apocado o avergonzado de un lugar. pop.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Ar</span></i><span class="da5">, </span><i><span class="da5">Ur.</span></i><span class="da5"> Retirarse de un lugar con discreci&#xF3;n, sin llamar la atenci&#xF3;n. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">l<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se cojo.</span><span class="da5"> loc. verb. </span><i><span class="da5">RD.</span></i><span class="da5"> Irse con un solo trago bebido.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">m<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se como los chepanos.</span><span class="da5"> loc. verb. </span><i><span class="da5">Pa.</span></i><span class="da5"> Marcharse sin decir adi&#xF3;s.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">n<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se como pan caliente.</span><span class="da5"> loc. verb. </span><i><span class="da5">ES</span></i><span class="da5">, </span><i><span class="da5">CR</span></i><span class="da5">, </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">PR</span></i><span class="da5">, </span><i><span class="da5">Co</span></i><span class="da5">, </span><i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ur.</span></i><span class="da5"> Vender </span><i><span class="da5">alguien</span></i><span class="da5"> un art&#xED;culo con prontitud. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">&#xF1;<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se con cualquier bola.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Cu.</span></i><span class="da5"> Seguir una sugerencia o consejo </span><span class="da0">que resulta err&#xF3;neo o desacertado.</span><span class="da5"> pop.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Cu.</span></i><span class="da5"> Tomar una decisi&#xF3;n err&#xF3;nea. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">o<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se con el gordo.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> Hacer autoestop. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">p<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se con la bola mala.</span><span class="da5"> loc. verb. </span><i><span class="da5">Cu.</span></i><span class="da5"> Tomar una decisi&#xF3;n desacertada. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">q<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se con la cabuya en la pata.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ve.</span></i><span class="da5"> Irse </span><i><span class="da5">alguien</span></i><span class="da5"> de un sitio sin pagar lo que ha consumido o adquirido.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">r<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se con la finta.</span><span class="da5"> loc. verb. </span><i><span class="da5">Mx.</span></i><span class="da5"> Dejarse llevar </span><i><span class="da5">alguien</span></i><span class="da5"> por lo dicho sin notar el enga&#xF1;o. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">s<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se con la soga a rastras.</span><span class="da5"> loc. verb. </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">Ve.</span></i><span class="da5"> Escapar </span><span class="da5">dejando pendientes deudas materiales o morales.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">t<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se con Pancho.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Gu.</span></i><span class="da5"> No cumplirse </span><i><span class="da5">algo</span></i><span class="da5"> que se hab&#xED;a prometido. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Gu.</span></i><span class="da5"> Incumplir </span><i><span class="da5">alguien</span></i><span class="da5"> una promesa o desentenderse de algo. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">iii.</span></td> <td><i><span class="da5">Gu.</span></i><span class="da5"> Perderse </span><i><span class="da5">algo</span></i><span class="da5"> de valor, </span><span class="da0">a causa de un descuido o un robo.</span><span class="da5"> pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">iv.</span></td> <td><i><span class="da5">Gu.</span></i><span class="da5"> Morirse </span><i><span class="da5">una persona</span></i><span class="da5">. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">u<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se cortado.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Ch.</span></i><span class="da5"> Salir derrotado o eliminado de una competici&#xF3;n. pop.</span><span class="da5"> &#x25C6; </span><span class="da3">irse cortina</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Ch.</span></i><span class="da5"> Salir expulsado de un lugar. pop.</span><span class="da5"> &#x25C6; </span><span class="da3">irse cortina</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">iii.</span></td> <td><i><span class="da5">Ch.</span></i><span class="da5"> Eyacular </span><i><span class="da5">una persona</span></i><span class="da5"> prematuramente. vulg; pop.</span><span class="da5"> &#x25C6; </span><span class="da3">irse cortina</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">iv.</span></td> <td><i><span class="da5">Ch.</span></i><span class="da5"> Resultar muerta </span><i><span class="da5">una persona.</span></i><span class="da5"> pop.</span><span class="da5"> &#x25C6; </span><span class="da3">irse cortina</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">v<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se cortina.</span> <i><span class="da5">Ch.</span></i> <span class="da3">irse cortado</span><span class="da5">. </span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">w<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de alita.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> Mostrar </span><i><span class="da5">alguien</span></i><span class="da5"> cobard&#xED;a. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">x<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de alivio.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Pe.</span></i><span class="da5"> Llevar a cabo un trabajo o tarea sin dificultad, realizarlo sin problemas. pop.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Ch.</span></i><span class="da5"> Sacar provecho del esfuerzo ajeno,</span><span class="da0"> en la ejecuci&#xF3;n de algo. </span><span class="da5">pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">y<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de boca.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Mx</span></i><span class="da5">, </span><i><span class="da5">ES</span></i><span class="da5">, </span><i><span class="da5">Ni</span></i><span class="da5">, </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">Ec</span></i><span class="da5">, </span><i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ar</span></i><span class="da5">, </span><i><span class="da5">Ur.</span></i><span class="da5"> Caerse de bruces </span><i><span class="da5">una persona</span></i><span class="da5">. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">ES</span></i><span class="da5">, </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">Ch</span></i><span class="da5">, </span><i><span class="da5">Ar</span></i><span class="da5">, </span><i><span class="da5">Ur.</span></i><span class="da5"> Hablar indiscretamente m&#xE1;s de la cuenta. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">iii.</span></td> <td><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">Ar.</span></i><span class="da5"> Dejarse llevar </span><i><span class="da5">una persona</span></i><span class="da5"> por las apariencias o los comentarios de alguien. pop.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">iv.</span></td> <td><i><span class="da5">Ar.</span></i><span class="da5"> Abalanzarse </span><i><span class="da5">una persona</span></i><span class="da5"> sobre alguien o algo. pop.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">v.</span></td> <td><i><span class="da5">Ar.</span></i><span class="da5"> Apresurarse, precipitarse. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">vi.</span></td> <td><i><span class="da5">Gu.</span></i><span class="da5"> Abusar de una persona, tratarla con una confianza impertinente. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">vii.</span></td> <td><i><span class="da5">RD.</span></i><span class="da5"> Descontrolarse o comportarse de forma exageradamente desinhibida.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">z<sup>5</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de bolsa.</span><span class="da5"> loc. verb. </span><i><span class="da5">ES.</span></i><span class="da5"> Dilapidar el dinero.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">a<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de bonche.</span><span class="da5"> loc. verb. </span><i><span class="da5">Cu</span></i><span class="da5">, </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">Ve.</span></i><span class="da5"> Irse de fiesta. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">b<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de cabeza.</span><span class="da5"> loc. verb. </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">Ar.</span></i><span class="da5"> juv. Extralimitarse </span><i><span class="da5">alguien</span></i><span class="da5"> en lo que dice o hace.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">c<sup>6</sup>. &#x1C1;</span></td> <td colspan="2"><span class="da0">~</span><span class="da3">se de caj&#xF3;n.</span><span class="da5"> loc. verb. </span><i><span class="da5">Co.</span></i><span class="da5"> Morirse </span><i><span class="da5">una persona</span></i><span class="da5">. delinc.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">d<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de capiuza.</span><span class="da5"> loc. verb. </span><i><span class="da5">Gu.</span></i><span class="da5"> Ausentarse del colegio un estudiante sin consentimiento de los padres o profesores.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">e<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de chacha.</span><span class="da5"> loc. verb. </span><i><span class="da5">Bo:O,C,S.</span></i><span class="da5"> Ausentarse del colegio un estudiante sin consentimiento alguno de los padres o de los profesores. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">f<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de chaqueta.</span><span class="da5"> loc. verb. </span><i><span class="da5">RD.</span></i><span class="da5"> Dejar un sitio disimuladamente.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">g<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de chicag&#xFC;ita.</span><span class="da5"> loc. verb. </span><i><span class="da5">ES.</span></i><span class="da5"> Enga&#xF1;arse o ser enga&#xF1;ado por alguien.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">h<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de coles.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ec.</span></i><span class="da5"> p.u. Vomitar.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">i<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de culo.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Gu</span></i><span class="da5">, </span><i><span class="da5">ES</span></i><span class="da5">, </span><i><span class="da5">Ni</span></i><span class="da5">, </span><i><span class="da5">Bo.</span></i><span class="da5"> Quedarse </span><i><span class="da5">alguien</span></i><span class="da5"> muy sorprendido. vulg; pop.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">PR.</span></i><span class="da5"> Negar </span><i><span class="da5">alguien</span></i><span class="da5"> algo enf&#xE1;ticamente. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">j<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de espalda.</span> <i><span class="da5">Ch.</span></i> <span class="da3">irse de espaldas</span><span class="da5">. </span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">k<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de espaldas.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Co</span></i><span class="da5">;</span><i><span class="da5"> Mx</span></i><span class="da5">, </span><i><span class="da5">Gu</span></i><span class="da5">, </span><i><span class="da5">ES</span></i><span class="da5">, </span><i><span class="da5">Ni</span></i><span class="da5">, </span><i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ch</span></i><span class="da5">, </span><i><span class="da5">Py</span></i><span class="da5">, pop + cult &#x2192; espon. Sorprenderse de algo. </span><span class="da5">&#x25C6;</span><span class="da5"> </span><span class="da3">irse de espalda</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Mx</span></i><span class="da5">, </span><i><span class="da5">Ni</span></i><span class="da5">, </span><i><span class="da5">Pe</span></i><span class="da5">, </span><i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ch</span></i><span class="da5">, </span><i><span class="da5">Py.</span></i><span class="da5"> Caer de espaldas. pop + cult &#x2192; espon. </span><span class="da5">&#x25C6;</span><span class="da5"> </span><span class="da3">irse de espalda</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">l<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de f&#xE1;bulas.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ec.</span></i><span class="da5"> p.u. Distraerse del tema que se est&#xE1; tratando. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">m<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de fai.</span><span class="da5"> loc. verb. </span><i><span class="da5">ES.</span></i><span class="da5"> No enterarse </span><i><span class="da5">alguien</span></i><span class="da5"> de algo.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">n<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de guinda.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ni</span></i><span class="da5">, </span><i><span class="da5">CR.</span></i><span class="da5"> Unirse, sin haber sido invitado, a un grupo de personas que se marchan a un lugar. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">&#xF1;<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de hocico.</span><span class="da5"> loc. verb. </span><i><span class="da5">Mx</span></i><span class="da5">, </span><i><span class="da5">CR</span></i><span class="da5">, </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">Bo</span></i><span class="da5">;</span><i><span class="da5"> Ec</span></i><span class="da5">, desp. Caer de bruces </span><i><span class="da5">alguien</span></i><span class="da5">. pop ^ fest.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">o<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de jeta.</span><span class="da5"> loc. verb. </span><i><span class="da5">Co:NE</span></i><span class="da5">, </span><i><span class="da5">Ve:O</span></i><span class="da5">, </span><i><span class="da5">Ec:C</span></i><span class="da5">, </span><i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ar.</span></i><span class="da5"> Caerse </span><i><span class="da5">alguien</span></i><span class="da5">. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">p<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de jobillos.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> No asistir a clase intencionadamente. est.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">q<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de la boca.</span> <i><span class="da5">Mx</span></i><span class="da5">, </span><i><span class="da5">Ch.</span></i> <span class="da3">irse de lengua</span><span class="da5">. </span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">r<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de lengua.</span><span class="da5"> loc. verb. </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">Ch.</span></i><span class="da5"> Hablar </span><i><span class="da5">alguien </span></i><span class="da5">m&#xE1;s de la cuenta. pop + cult &#x2192; espon. </span><span class="da5">&#x25C6;</span><span class="da5"> </span><span class="da3">irse de la boca</span><span class="da5">;</span><span class="da3"> irse de lenguas</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">s<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de lenguas.</span> <i><span class="da5">RD.</span></i> <span class="da3">irse de lengua</span><span class="da5">. </span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">t<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de mambo.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ar</span></i><span class="da5">, </span><i><span class="da5">Ur.</span></i><span class="da5"> juv. Hacer o decir </span><i><span class="da5">algo</span></i><span class="da5"> inoportuno o fuera de lugar. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">u<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de moco.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Ec:E,O.</span></i><span class="da5"> Llorar. pop.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Ec.</span></i><span class="da5"> Prorrumpir en llanto. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">v<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de nalgas.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ni.</span></i><span class="da5"> Quedarse </span><i><span class="da5">alguien</span></i><span class="da5"> muy sorprendido. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">w<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de patas.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ec.</span></i><span class="da5"> Cometer un grave error </span><i><span class="da5">una persona</span></i> <span class="da0">al decir o hacer algo.</span><span class="da5"> pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">x<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de pico.</span><span class="da5"> loc. verb. </span><i><span class="da5">Pe.</span></i><span class="da5"> Hablar </span><i><span class="da5">alguien</span></i><span class="da5"> de manera indiscreta o excesivamente. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">y<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de pinta.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Bo.</span></i><span class="da5"> p.u. No asistir a las clases. est.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">ES.</span></i><span class="da5"> Salir de parranda, vagar.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">z<sup>6</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de poto.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ch.</span></i><span class="da5"> Caerse de espaldas. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">a<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de punta.</span><span class="da5"> loc. verb. </span><i><span class="da5">Py.</span></i><span class="da5"> Caer de cabeza, de bruces. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">b<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de pu&#xF1;ete.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ec.</span></i><span class="da5"> Llegar a las manos. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">c<sup>7</sup>. &#x1C1;</span></td> <td colspan="2"><span class="da0">~</span><span class="da3">se de un viaje.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ch.</span></i><span class="da5"> Acabarse o hacerse </span><i><span class="da5">algo</span></i><span class="da5"> con rapidez o precipitaci&#xF3;n. pop ^ fest.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">d<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se de vuelta y vuelta.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ch.</span></i><span class="da5"> Intercambiar roles durante una relaci&#xF3;n homosexual. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">e<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se del aire.</span><span class="da5"> loc. verb. </span><i><span class="da5">Cu.</span></i><span class="da5"> Morirse una persona. pop.</span><span class="da5"> &#x25C6; </span><span class="da3">irse del parque</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">f<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se del parque.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><i><span class="da5">Cu.</span></i> <span class="da3">irse del aire</span><span class="da5">. pop.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Cu.</span></i><span class="da5"> Romperse </span><i><span class="da5">algo</span></i><span class="da5">. pop.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">iii.</span></td> <td><i><span class="da5">Cu.</span></i><span class="da5"> Terminar una relaci&#xF3;n amorosa. pop.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">iv.</span></td> <td><i><span class="da5">Cu.</span></i><span class="da5"> Fracasar un proyecto. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">g<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se el agua.</span><span class="da5"> loc. verb. </span><i><span class="da5">Mx</span></i><span class="da5">, </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">Bo</span></i><span class="da5">;</span><i><span class="da5"> PR</span></i><span class="da5">, obsol. Dejar de llover. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">h<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se el alma.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ni</span></i><span class="da5">, </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">PR.</span></i><span class="da5"> Asustarse </span><i><span class="da5">una persona</span></i><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">i<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se el alma a los talones.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Ch.</span></i><span class="da5"> Desanimarse </span><i><span class="da5">alguien</span></i><span class="da5">. pop.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">CR.</span></i><span class="da5"> Experimentar p&#xE1;nico </span><i><span class="da5">alguien</span></i><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">j<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se el alma al culo.</span><span class="da5"> loc. verb. </span><i><span class="da5">ES.</span></i><span class="da5"> Sentir pavor por algo. vulg; pop.</span><span class="da5"> &#x25C6; </span><span class="da3">bajarse el alma al culo</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">k<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se el cacahuate a la cabeza.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ho.</span></i><span class="da5"> Creerse </span><i><span class="da5">una persona</span></i><span class="da5"> m&#xE1;s de lo que vale. desp.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">l<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se el cuajo a los talones.</span><span class="da5"> loc. verb. </span><i><span class="da5">CR.</span></i><span class="da5"> obsol. Experimentar </span><i><span class="da5">alguien</span></i><span class="da5"> temor.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">m<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se el p&#xE1;jaro.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ho</span></i><span class="da5">, </span><i><span class="da5">Ni.</span></i><span class="da5"> Olvidar moment&#xE1;neamente </span><i><span class="da5">algo</span></i><span class="da5">, despistarse.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">n<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se el toro con la veta.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ec:S.</span></i><span class="da5"> obsol. Apropiarse </span><i><span class="da5">alguien</span></i><span class="da5"> indebidamente de contribuciones filantr&#xF3;picas y de caridad. rur.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">&#xF1;<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se en amagues.</span> <i><span class="da5">Ar</span></i><span class="da5">, </span><i><span class="da5">Ur.</span></i> <span class="da3">irse en aprontes</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">o<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se en aprontes.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ch</span></i><span class="da5">, </span><i><span class="da5">Ar</span></i><span class="da5">, </span><i><span class="da5">Ur.</span></i><span class="da5"> Dilatarse innecesariamente en los preparativos de una acci&#xF3;n y finalmente no llevarla a cabo. pop + cult &#x2192; espon. </span><span class="da5">&#x25C6;</span><span class="da5"> </span><span class="da3">irse en amagues</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">p<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se en blanco.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><i><span class="da5">Cu</span></i><span class="da5">, </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">PR.</span></i> <span class="da3">irse sin bola</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Ec.</span></i><span class="da5"> No culminar un hombre el acto sexual </span><span class="da0">por haber tenido una eyaculaci&#xF3;n precoz. </span><span class="da5">pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">iii.</span></td> <td><i><span class="da5">Cu.</span></i> <i><span class="da5">En el </span></i><i><a href='beisbol'>beisbol</a></i><span class="da5">, no poder hacer </span><i><a href='hit'>hit</a></i><span class="da5"> el bateador.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">iv.</span></td> <td><i><span class="da5">Cu.</span></i> <i><span class="da5">En el </span></i><i><a href='beisbol'>beisbol</a></i><span class="da5">, no anotar ninguna carrera un equipo.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">q<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se en caca.</span> <i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ch.</span></i> <span class="da3">irse en mierda</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">r<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se en caldo.</span><span class="da5"> loc. verb. </span><i><span class="da5">Pe.</span></i><span class="da5"> No conseguir realizar una acci&#xF3;n </span><span class="da0">al equivocarse o fallar al intentar hacerla.</span><span class="da5"> pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">s<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se en coche.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">Pe.</span></i><span class="da5"> Resultar </span><i><span class="da5">alguien</span></i><span class="da5"> muy favorecido. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Cu.</span></i><span class="da5"> Terminar </span><i><span class="da5">alguien</span></i><span class="da5"> un asunto mejor de lo que esperaba. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">t<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se en la colada.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">CR</span></i><span class="da5">, </span><i><span class="da5">RD.</span></i><span class="da5"> Integrarse una cosa material en otras. pop.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">ES.</span></i><span class="da5"> No ser </span><i><span class="da5">alguien</span></i><span class="da5"> culpable de algo y, pese a ello, recibir el mismo trato que otros.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">iii.</span></td> <td><i><span class="da5">CR.</span></i><span class="da5"> Integrarse </span><i><span class="da5">alguien</span></i><span class="da5"> en un grupo de personas </span><span class="da0">para seguirlas a donde se dirigen</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">u<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se en la de fay.</span><span class="da5"> loc. verb. </span><i><span class="da5">ES.</span></i><span class="da5"> Cometer un error.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">v<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se en la profunda.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ch.</span></i><span class="da5"> Pensar en exceso o en profundidad. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">w<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se en la tira.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">CR.</span></i><span class="da5"> Morir </span><i><span class="da5">alguien</span></i><span class="da5">. pop ^ fest.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">CR.</span></i><span class="da5"> Estropearse o descomponerse </span><i><span class="da5">algo</span></i><span class="da5">. pop ^ fest.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">x<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se en la volada.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ch.</span></i><span class="da5"> Entusiasmarse y dejarse llevar por algo. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">y<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se en (la) mala.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ch.</span></i><span class="da5"> juv. Enojarse, enfadarse. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">z<sup>7</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se en mierda.</span><span class="da5"> loc. verb. </span><i><span class="da5">Cu</span></i><span class="da5">, </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ch.</span></i><span class="da5"> Tener </span><i><span class="da5">alguien</span></i><span class="da5"> diarrea. vulg; pop.</span><span class="da5"> &#x25C6; </span><span class="da3">irse en caca</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">a<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se en p&#xE1;lida.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ch.</span></i><span class="da5"> juv. Vomitar. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">b<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se en sangre.</span><span class="da5"> loc. verb. </span><i><span class="da5">CR</span></i><span class="da5">, </span><i><span class="da5">Cu</span></i><span class="da5">, </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ch</span></i><span class="da5">, </span><i><span class="da5">Ar</span></i><span class="da5">, </span><i><span class="da5">Ur.</span></i><span class="da5"> Desangrarse </span><i><span class="da5">alguien</span></i><span class="da5">. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">c<sup>8</sup>. &#x1C1;</span></td> <td colspan="2"><span class="da0">~</span><span class="da3">se en vicio.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Ch</span></i><span class="da5">;</span><i><span class="da5"> Gu</span></i><span class="da5">, </span><i><span class="da5">Pa</span></i><span class="da5">, </span><i><span class="da5">Cu</span></i><span class="da5">, </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">Co</span></i><span class="da5">, rur;</span><i><span class="da5"> Ur</span></i><span class="da5">, pop + cult &#x2192; espon. Dar una planta muchas hojas y crecer en exceso, pero sin dar flores o frutos.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Cu.</span></i><span class="da5"> Crecer mucho un ni&#xF1;o o adolescente.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">d<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se hasta donde no es.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ni.</span></i><span class="da5"> Equivocarse gravemente.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">e<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se hasta el &#xF1;ame.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> Caer </span><i><span class="da5">alguien</span></i><span class="da5"> en lo m&#xE1;s bajo. pop + cult &#x2192; espon.</span><span class="da5"> &#x25C6; </span><span class="da3">irse hasta los lerenes</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">f<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se hasta los lerenes.</span> <i><span class="da5">PR.</span></i> <span class="da3">irse hasta el &#xF1;ame</span><span class="da5">. rur.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">g<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se la bolita.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ch.</span></i> <i><span class="da5">En el juego de la ruleta</span></i><span class="da5">, comenzar el juego en la apuesta correspondiente. pop.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Ch.</span></i><span class="da5"> Dar inicio una actividad cualquiera. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">h<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se la pajarita.</span><span class="da5"> loc. verb. </span><i><span class="da5">CR.</span></i><span class="da5"> Pas&#xE1;rsele por alto </span><i><span class="da5">algo</span></i><span class="da5"> a</span><i><span class="da5"> alguien</span></i><span class="da5">. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">i<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se la yegua.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> Excederse </span><i><span class="da5">alguien</span></i><span class="da5"> en un juicio o en una acci&#xF3;n </span><span class="da0">por haber perdido algo de vista</span><span class="da5">. rur.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">j<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se las cabras.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Ch.</span></i><span class="da5"> Eyacular durante la noche. pop ^ fest.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Gu.</span></i><span class="da5"> Eyacular. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">k<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se las chivas.</span><span class="da5"> loc. verb. </span><i><span class="da5">Gu.</span></i><span class="da5"> Eyacular. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">l<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se para adentro.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ch.</span></i><span class="da5"> Abstraerse, reconcentrarse </span><i><span class="da5">alguien</span></i><span class="da5"> voluntaria o involuntariamente. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">m<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se para el carajo.</span><span class="da5"> loc. verb. </span><i><span class="da5">Gu</span></i><span class="da5">, </span><i><span class="da5">Ni</span></i><span class="da5">, </span><i><span class="da5">Cu</span></i><span class="da5">, </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">PR</span></i><span class="da5">;</span><i><span class="da5"> Ec</span></i><span class="da5">, vulg. Largarse.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">n<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se para el carrizo.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Ve.</span></i><span class="da5"> Marcharse a otro lugar.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Ve.</span></i><span class="da5"> Rechazar con enfado a </span><i><span class="da5">alguien</span></i><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">&#xF1;<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se para el otro potrero.</span><span class="da5"> loc. verb. </span><i><span class="da5">CR.</span></i><span class="da5"> Morir </span><i><span class="da5">una persona</span></i><span class="da5">. pop + cult &#x2192; espon ^ fest.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">o<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se para la pinga.</span><span class="da5"> loc. verb. </span><i><span class="da5">Cu.</span></i><span class="da5"> Largarse. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">p<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se para las ventas del carajo.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> Desear </span><i><span class="da5">una persona</span></i><span class="da5"> que desaparezca alguien o la desaparici&#xF3;n propia. vulg; pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">q<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se para Quebradillas.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> obsol. Quebrar, cesar un negocio </span><span class="da0">por problemas econ&#xF3;micos.</span><span class="da5"> pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">r<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se pitando la Borinque&#xF1;a.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> Marcharse </span><i><span class="da5">alguien</span></i><span class="da5"> desairado, con enojo. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">s<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se por el alambre.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ch.</span></i><span class="da5"> Dejar de comer una de las comidas diarias. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">t<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se por el camino viejo.</span><span class="da5"> loc. verb. </span><i><span class="da5">Gu</span></i><span class="da5">, </span><i><span class="da5">Pa</span></i><span class="da5">, </span><i><span class="da5">Cu</span></i><span class="da5">, </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">Co</span></i><span class="da5">, </span><i><span class="da5">Ve</span></i><span class="da5">, </span><i><span class="da5">Ch</span></i><span class="da5">;</span><i><span class="da5"> Ec</span></i><span class="da5">, p.u. Atragantarse </span><i><span class="da5">alguien</span></i><span class="da5"> con un alimento o l&#xED;quido. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">u<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se por el chorro.</span><span class="da5"> loc. verb. </span><i><span class="da5">PR.</span></i><span class="da5"> Dilapidar, despilfarrar </span><i><span class="da5">alguien</span></i> <i><span class="da5">algo</span></i><span class="da5">. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">v<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se por la calle de tierra.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ho:N.</span></i><span class="da5"> Preferir </span><i><span class="da5">alguien</span></i><span class="da5"> a personas de su mismo sexo.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">w<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se por ojo.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ch.</span></i><span class="da5"> No lograr lo que se anhela. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">x<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se silbando bajito.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Ar.</span></i><span class="da5"> Irse apocado o avergonzado de un lugar. pop.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Ur.</span></i><span class="da5"> Retirarse de un lugar con discreci&#xF3;n, sin llamar la atenci&#xF3;n. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">y<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3">se sin bola.</span><span class="da5"> loc. verb. </span><i><span class="da5">RD.</span></i><span class="da5"> Fracasar o no tener &#xE9;xito en algo que se emprende. pop + cult &#x2192; espon.</span><span class="da5"> &#x25C6; </span><span class="da3">irse en blanco</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">z<sup>8</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xED;rsela campechaneando.</span><span class="da5"> loc. verb. </span><i><span class="da5">Mx.</span></i><span class="da5"> Salir adelante, arregl&#xE1;rselas en medio de apuros. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">a<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xED;rsele adentro.</span><span class="da5"> loc. verb. </span><i><span class="da5">CR.</span></i><span class="da5"> Arremeter contra alguien </span><span class="da0">para llegar a las manos.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">b<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xED;rsele arriba.</span> <i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">PR</span></i><span class="da5">;</span><i><span class="da5"> Ur</span></i><span class="da5">, pop + cult &#x2192; espon. </span><span class="da3">&#xED;rsele encima</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">c<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xED;rsele el alma.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ni</span></i><span class="da5">, </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">Bo.</span></i><span class="da5"> Sentir </span><i><span class="da5">alguien</span></i><span class="da5"> pavor </span><i><span class="da5">por algo</span></i><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">d<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xED;rsele el avi&#xF3;n.</span><span class="da5"> loc. verb. </span><i><span class="da5">Mx</span></i><span class="da5">, </span><i><span class="da5">ES</span></i><span class="da5">, </span><i><span class="da5">Ni.</span></i><span class="da5"> Perder </span><i><span class="da5">alguien</span></i><span class="da5"> moment&#xE1;neamente la ilaci&#xF3;n, u olvidarse de algo. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">e<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xED;rsele el culo.</span><span class="da5"> loc. verb. </span><i><span class="da5">ES.</span></i><span class="da5"> Asustarse </span><i><span class="da5">alguien</span></i><span class="da5"> mucho </span><span class="da0">por algo que ocurre de forma repentina o inesperada.</span><span class="da5"> pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">f<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xED;rsele el p&#xE1;jaro.</span><span class="da5"> loc. verb. </span><i><span class="da5">Gu</span></i><span class="da5">, </span><i><span class="da5">Ho.</span></i><span class="da5"> Perder </span><i><span class="da5">alguien</span></i><span class="da5"> la concentraci&#xF3;n, distraerse. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">g<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xED;rsele el tren.</span><span class="da5"> loc. verb. </span><i><span class="da5">Mx</span></i><span class="da5">, </span><i><span class="da5">ES</span></i><span class="da5">, </span><i><span class="da5">PR</span></i><span class="da5">, </span><i><span class="da5">Pe</span></i><span class="da5">, </span><i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ch.</span></i> <span class="da3">dejar el tren</span><span class="da5">, quedarse soltera una mujer. pop ^ fest.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">h<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xED;rsele en collera.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ch.</span></i><span class="da5"> Escap&#xE1;rsele a</span><i><span class="da5"> alguien</span></i><span class="da5"> una cosa o perder el control de algo o alguien. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">i<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xED;rsele encima.</span><span class="da5"> loc. verb. </span><i><span class="da5">Mx</span></i><span class="da5">, </span><i><span class="da5">ES</span></i><span class="da5">, </span><i><span class="da5">Ni</span></i><span class="da5">, </span><i><span class="da5">CR</span></i><span class="da5">, </span><i><span class="da5">Cu</span></i><span class="da5">, </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">Ec</span></i><span class="da5">, </span><i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ar</span></i><span class="da5">;</span><i><span class="da5"> Ur</span></i><span class="da5">, pop + cult &#x2192; espon. Embestir a </span><i><span class="da5">alguien</span></i><span class="da5">, acometerlo, atacarlo.</span><span class="da5"> &#x25C6; </span><span class="da3">&#xED;rsele arriba</span><span class="da5">; </span><span class="da3">venirle arriba</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">j<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xED;rsele la albarda.</span><span class="da5"> loc. verb. </span><i><span class="da5">Gu.</span></i><span class="da5"> Perder </span><i><span class="da5">alguien</span></i><span class="da5"> el dominio de s&#xED; mismo y actuar de forma irreflexiva o violenta.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">k<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xED;rsele la baba.</span><span class="da5"> loc. verb. </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">Bo.</span></i><span class="da5"> Experimentar </span><i><span class="da5">alguien </span></i><span class="da5">gran complacencia o embeleso viendo u oyendo cosas que agradan a los sentidos. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">l<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xED;rsele la boca.</span><span class="da5"> loc. verb. </span><i><span class="da5">Cu</span></i><span class="da5">, </span><i><span class="da5">RD.</span></i><span class="da5"> Hablar mucho y de forma descort&#xE9;s o desconsiderada.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3"> m<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xED;rsele la catalina.</span><span class="da5"> loc. verb. </span><i><span class="da5">Cu.</span></i><span class="da5"> Perder </span><i><span class="da5">alguien</span></i><span class="da5"> el juicio. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">n<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xED;rsele la mano en pollo.</span><span class="da5"> loc. verb. </span><i><span class="da5">Pa.</span></i><span class="da5"> Exagerar </span><i><span class="da5">alguien</span></i> <i><span class="da5">algo</span></i><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">&#xF1;<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xED;rsele la onda.</span><span class="da5"> loc. verb. </span><i><span class="da5">Mx</span></i><span class="da5">, </span><i><span class="da5">Ho</span></i><span class="da5">, </span><i><span class="da5">ES</span></i><span class="da5">, </span><i><span class="da5">Ni</span></i><span class="da5">, </span><i><span class="da5">CR</span></i><span class="da5">, </span><i><span class="da5">Cu</span></i><span class="da5">, </span><i><span class="da5">Co</span></i><span class="da5">, </span><i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ch.</span></i><span class="da5"> Perder </span><i><span class="da5">alguien</span></i><span class="da5"> moment&#xE1;neamente la ilaci&#xF3;n, u olvidarse de algo. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">o<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xED;rsele la paloma.</span><span class="da5"> loc. verb. </span><i><span class="da5">Co.</span></i><span class="da5"> Olvidarse </span><i><span class="da5">alguien</span></i><span class="da5"> de lo que iba a decir o hacer. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">p<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xED;rsele la sangre a los pies.</span><span class="da5"> loc. verb. </span><i><span class="da5">Mx.</span></i><span class="da5"> Asustarse </span><i><span class="da5">alguien</span></i><span class="da5"> mucho, aterrorizarse. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">q<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xED;rsele la vara.</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. verb. </span><i><span class="da5">Cu.</span></i><span class="da5"> Pasar por una mala situaci&#xF3;n econ&#xF3;mica.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">Gu.</span></i><span class="da5"> Perder </span><i><span class="da5">alguien</span></i><span class="da5"> la concentraci&#xF3;n, distraerse. pop + cult &#x2192; espon.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">r<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xED;rsele las cabras.</span><span class="da5"> loc. verb. </span><i><span class="da5">Mx.</span></i><span class="da5"> Actuar </span><i><span class="da5">alguien</span></i><span class="da5"> de manera impulsiva, sin pensar. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">s<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xED;rsele las patas.</span><span class="da5"> loc. verb. </span><i><span class="da5">Pa.</span></i><span class="da5"> Cometer </span><i><span class="da5">alguien</span></i><span class="da5"> una imprudencia. pop + cult &#x2192; espon ^ fest.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">t<sup>9</sup>. &#x1C1;</span></td> <td colspan="2"><span class="da3">&#xED;rsele los humos.</span><span class="da5"> loc. verb. </span><i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ch.</span></i><span class="da5"> Envanecerse </span><i><span class="da5">alguien</span></i><span class="da5"> a partir de un suceso que le ha sido favorable o le mejora su situaci&#xF3;n. pop + cult &#x2192; espon.</span><span class="da5"> &#x25C6; </span><span class="da3">&#xED;rsele los humos a la cabeza</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">u<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xED;rsele los humos a la cabeza.</span> <i><span class="da5">RD</span></i><span class="da5">, </span><i><span class="da5">PR</span></i><span class="da5">, </span><i><span class="da5">Ch.</span></i> <span class="da3">&#xED;rsele los humos</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">v<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xED;rsele los pavos.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ch.</span></i><span class="da5"> Cometer </span><i><span class="da5">alguien</span></i><span class="da5"> un error. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">w<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xED;rsele los tapones.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ve.</span></i><span class="da5"> Perder </span><i><span class="da5">alguien</span></i><span class="da5"> la noci&#xF3;n de las cosas. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">x<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xED;rsele por alto.</span><span class="da5"> loc. verb. </span><i><span class="da5">Gu</span></i><span class="da5">, </span><i><span class="da5">Ni</span></i><span class="da5">, </span><i><span class="da5">CR.</span></i><span class="da5"> Olvid&#xE1;rsele </span><i><span class="da5">algo</span></i><span class="da5"> a</span><i><span class="da5"> alguien</span></i><span class="da5">. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">y<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">no </span><span class="da0">~</span><span class="da3"> para el baile.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ve.</span></i><span class="da5"> No participar en alguna actividad o no lograr &#xE9;xito en la misma.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">z<sup>9</sup>. &#x1C1; </span></td><td colspan="2"><span class="da3">no </span><span class="da0">~</span><span class="da3">se chancho con mazorca.</span><span class="da5"> loc. verb. </span><i><span class="da5">Ho</span></i><span class="da5">, </span><i><span class="da5">ES.</span></i><span class="da5"> Darse cuenta </span><i><span class="da5">una persona</span></i><span class="da5"> de todo lo que sucede. pop.</span></td></tr><tr><td> </td><td class="da7"><span class="da3">&#x25A0;</span></td><td> </td><td> </td><td> </td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">a. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> como entierro de pobre.</span><span class="da5"> loc. adv. </span><i><span class="da5">Ho</span></i><span class="da5">, </span><i><span class="da5">CR.</span></i><span class="da5"> R&#xE1;pidamente, velozmente.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">b. &#x1C1;</span></td> <td colspan="2"><span class="da3">&#xA1;va pues!</span><span class="da5"> loc. interj. </span><i><span class="da5">Ve:O.</span></i><span class="da5"> Expresa contrariedad. pop.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">c. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xA1;vaya pues!</span><span class="da5"> loc. interj. </span><i><span class="da5">ES.</span></i><span class="da5"> Expresa acuerdo en algo o autorizaci&#xF3;n para algo.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">d. &#x1C1; </span></td><td colspan="2"><span class="da3">y va de.</span><span class="da5"> loc. interj. </span><i><span class="da5">Ho</span></i><span class="da5">, </span><i><span class="da5">ES.</span></i><span class="da5"> Expresa reiteraci&#xF3;n de una acci&#xF3;n o insistencia. rur.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">e. &#x1C1; </span></td><td colspan="2"><span class="da3">&#xA1;ya vas!</span> </td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">i.</span></td> <td><span class="da5">loc. interj. </span><i><span class="da5">ES</span></i><span class="da5">, </span><i><span class="da5">Ni.</span></i><span class="da5"> Expresa impresi&#xF3;n por algo que alguien dice o hace y que resulta gracioso o divertido.</span></td></tr><tr><td> </td><td> </td><td> </td><td class="da7"><span class="da3">ii.</span></td> <td><i><span class="da5">ES</span></i><span class="da5">, </span><i><span class="da5">Ni.</span></i><span class="da5"> Expresa impresi&#xF3;n por algo que alguien dice o hace y que se condiera falto de discreci&#xF3;n o prudencia.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">f. &#x1C1; </span></td><td colspan="2"><span class="da3">ya voy, To&#xF1;o.</span><span class="da5"> loc. adv. </span><i><span class="da5">Co.</span></i><span class="da5"> De ninguna manera. pop.</span></td></tr><tr><td> </td><td class="da7"><span class="da3">&#x25EA;</span></td><td> </td><td> </td><td> </td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">a. &#x1C1; </span></td><td colspan="2"><span class="da3">no </span><span class="da0">~</span><span class="da3"> a ning&#xFA;n Pereira.</span><span class="da5"> fr. prov. </span><i><span class="da5">Co:O.</span></i><span class="da5"> Indica que si algo se hace de forma perezosa y desinteresada no se lograr&#xE1;.</span></td></tr></table>
+</entry>
+<p class="o"><center><i><span class="d7">Diccionario de americanismos © 2010<br/>Asociación de Academias de la Lengua Española © Todos los derechos reservados</span></i></center></p><div class="compartir"><a title="Compartir en Facebook" class="resp-sharing-button__link" href="https://facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fir" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--facebook resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M18.77 7.46H14.5v-1.9c0-.9.6-1.1 1-1.1h3V.5h-4.33C10.24.5 9.5 3.44 9.5 5.32v2.15h-3v4h3v12h5v-12h3.85l.42-4z"/></svg></div></div></a>
+<a title="Compartir en Twitter" class="resp-sharing-button__link" href="https://twitter.com/intent/tweet/?text=ir, irse - Diccionario de americanismos&url=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fir" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--twitter resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M23.44 4.83c-.8.37-1.5.38-2.22.02.93-.56.98-.96 1.32-2.02-.88.52-1.86.9-2.9 1.1-.82-.88-2-1.43-3.3-1.43-2.5 0-4.55 2.04-4.55 4.54 0 .36.03.7.1 1.04-3.77-.2-7.12-2-9.36-4.75-.4.67-.6 1.45-.6 2.3 0 1.56.8 2.95 2 3.77-.74-.03-1.44-.23-2.05-.57v.06c0 2.2 1.56 4.03 3.64 4.44-.67.2-1.37.2-2.06.08.58 1.8 2.26 3.12 4.25 3.16C5.78 18.1 3.37 18.74 1 18.46c2 1.3 4.4 2.04 6.97 2.04 8.35 0 12.92-6.92 12.92-12.93 0-.2 0-.4-.02-.6.9-.63 1.96-1.22 2.56-2.14z"/></svg></div></div></a>
+<a title="Compartir por correo electrónico" class="resp-sharing-button__link" href="/cdn-cgi/l/email-protection#83bcf0f6e1e9e6e0f7beeaf1afa3eaf1f0e6a3aea3c7eae0e0eaecede2f1eaeca3e7e6a3e2eee6f1eae0e2edeaf0eeecf0a5e1ece7fabeebf7f7f3f0b9acacf4f4f4ade2f0e2efe6adecf1e4ace7e2eee6f1aceaf1a6b3c2a6b3c2caada3b2ada3cbeca3afa3c6d0a3afa3cdeaa3afa3c1eca3afa3d6f1ada3c6fae2e0f6efe2f1afa3e6fbf3f6eff0e2f1a3e0eceda3f1e2f3eae7e6f9a3faa3e5f6e6f1f9e2a3e6efa3f0e6eee6edada3f3ecf3ada3b1ada3c0ebada3c6fbf3e6f1eaeee6edf7e2f1a3e2efe4f6eae6eda3f6eda3ecf1e4e2f0eeecada3f3ecf3ada3cacaada3b2ada3cbecad" target="_self" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--email resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M22 4H2C.9 4 0 4.9 0 6v12c0 1.1.9 2 2 2h20c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zM7.25 14.43l-3.5 2c-.08.05-.17.07-.25.07-.17 0-.34-.1-.43-.25-.14-.24-.06-.55.18-.68l3.5-2c.24-.14.55-.06.68.18.14.24.06.55-.18.68zm4.75.07c-.1 0-.2-.03-.27-.08l-8.5-5.5c-.23-.15-.3-.46-.15-.7.15-.22.46-.3.7-.14L12 13.4l8.23-5.32c.23-.15.54-.08.7.15.14.23.07.54-.16.7l-8.5 5.5c-.08.04-.17.07-.27.07zm8.93 1.75c-.1.16-.26.25-.43.25-.08 0-.17-.02-.25-.07l-3.5-2c-.24-.13-.32-.44-.18-.68s.44-.32.68-.18l3.5 2c.24.13.32.44.18.68z"/></svg></div></div></a>
+<a title="Compartir en WhatsApp" class="resp-sharing-button__link" href="whatsapp://send?text=ir, irse - Diccionario de americanismos%20https%3A%2F%2Fwww.asale.org%2Fdamer%2Fir" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--whatsapp resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20.1 3.9C17.9 1.7 15 .5 12 .5 5.8.5.7 5.6.7 11.9c0 2 .5 3.9 1.5 5.6L.6 23.4l6-1.6c1.6.9 3.5 1.3 5.4 1.3 6.3 0 11.4-5.1 11.4-11.4-.1-2.8-1.2-5.7-3.3-7.8zM12 21.4c-1.7 0-3.3-.5-4.8-1.3l-.4-.2-3.5 1 1-3.4L4 17c-1-1.5-1.4-3.2-1.4-5.1 0-5.2 4.2-9.4 9.4-9.4 2.5 0 4.9 1 6.7 2.8 1.8 1.8 2.8 4.2 2.8 6.7-.1 5.2-4.3 9.4-9.5 9.4zm5.1-7.1c-.3-.1-1.7-.9-1.9-1-.3-.1-.5-.1-.7.1-.2.3-.8 1-.9 1.1-.2.2-.3.2-.6.1s-1.2-.5-2.3-1.4c-.9-.8-1.4-1.7-1.6-2-.2-.3 0-.5.1-.6s.3-.3.4-.5c.2-.1.3-.3.4-.5.1-.2 0-.4 0-.5C10 9 9.3 7.6 9 7c-.1-.4-.4-.3-.5-.3h-.6s-.4.1-.7.3c-.3.3-1 1-1 2.4s1 2.8 1.1 3c.1.2 2 3.1 4.9 4.3.7.3 1.2.5 1.6.6.7.2 1.3.2 1.8.1.6-.1 1.7-.7 1.9-1.3.2-.7.2-1.2.2-1.3-.1-.3-.3-.4-.6-.5z"/></svg></div></div></a>
+<a title="Compartir en Telegram" class="resp-sharing-button__link" href="https://telegram.me/share/url?text=ir, irse - Diccionario de americanismos&url=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fir" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--telegram resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M.707 8.475C.275 8.64 0 9.508 0 9.508s.284.867.718 1.03l5.09 1.897 1.986 6.38a1.102 1.102 0 0 0 1.75.527l2.96-2.41a.405.405 0 0 1 .494-.013l5.34 3.87a1.1 1.1 0 0 0 1.046.135 1.1 1.1 0 0 0 .682-.803l3.91-18.795A1.102 1.102 0 0 0 22.5.075L.706 8.475z"/></svg></div></div></a>
+<a title="Compartir en Pinterest" class="resp-sharing-button__link" href="https://pinterest.com/pin/create/button/?url=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fir&media=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fir&description=I. 1. Ho , ES , Ni , Bo , Ur. Eyacular, expulsar con rapidez y fuerza el semen. pop. 2. Ch. Experimentar alguien un orgasmo. pop. II. 1. Ho." target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--pinterest resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.14.5C5.86.5 2.7 5 2.7 8.75c0 2.27.86 4.3 2.7 5.05.3.12.57 0 .66-.33l.27-1.06c.1-.32.06-.44-.2-.73-.52-.62-.86-1.44-.86-2.6 0-3.33 2.5-6.32 6.5-6.32 3.55 0 5.5 2.17 5.5 5.07 0 3.8-1.7 7.02-4.2 7.02-1.37 0-2.4-1.14-2.07-2.54.4-1.68 1.16-3.48 1.16-4.7 0-1.07-.58-1.98-1.78-1.98-1.4 0-2.55 1.47-2.55 3.42 0 1.25.43 2.1.43 2.1l-1.7 7.2c-.5 2.13-.08 4.75-.04 5 .02.17.22.2.3.1.14-.18 1.82-2.26 2.4-4.33.16-.58.93-3.63.93-3.63.45.88 1.8 1.65 3.22 1.65 4.25 0 7.13-3.87 7.13-9.05C20.5 4.15 17.18.5 12.14.5z"/></svg></div></div></a>
+<a title="Compartir en LinkedIn" class="resp-sharing-button__link" href="https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fir&title=ir, irse - Diccionario de americanismos&summary=I. 1. Ho , ES , Ni , Bo , Ur. Eyacular, expulsar con rapidez y fuerza el semen. pop. 2. Ch. Experimentar alguien un orgasmo. pop. II. 1. Ho.&source=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fir" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--linkedin resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
+<svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M6.5 21.5h-5v-13h5v13zM4 6.5C2.5 6.5 1.5 5.3 1.5 4s1-2.4 2.5-2.4c1.6 0 2.5 1 2.6 2.5 0 1.4-1 2.5-2.6 2.5zm11.5 6c-1 0-2 1-2 2v7h-5v-13h5V10s1.6-1.5 4-1.5c3 0 5 2.2 5 6.3v6.7h-5v-7c0-1-1-2-2-2z"/></svg></div></div></a></div></div>
+</div>
+<div data-nosnippet class="col-xs-12 col-md-4 bloque-txt">
+<h2 class="ayuda">Más información</h2>
+<div class="view-node-navigation"><ul class="menu"><li class="leaf d0"><a target="_blank" title="Prólogo de la obra" class="tooltip" href="https://www.asale.org/sites/default/files/Prologo_Diccionario_de_americanismos.pdf">Prólogo</a> de la obra</li><li class="leaf d0"><a target="_blank" title="Preliminares (abreviaturas) de la obra" class="tooltip" href="https://www.asale.org/sites/default/files/Abreviaturas_del_DA.pdf">Preliminares</a> (abreviaturas) de la obra</li></ul></div>
+
+		
+<div><h2 class="ayuda">Rueda de palabras</h2>
+<div>
+<ul class='rueda'><li><a href='/damer/iporama'>iporama</a></li><li><a href='/damer/ipso'>ipso</a></li><li><a href='/damer/ipure'>ipure</a></li><li><a href='/damer/¡ique!'>¡ique!</a></li><li><a href='/damer/ique'>ique</a></li><li><a href='/damer/iqui'>iqui</a></li><li><a href='/damer/iquimite'>iquimite</a></li><li><b>ir</b></li><li><a href='/damer/¡ira!'>¡ira!</a></li><li><a href='/damer/ira'>ira</a></li><li><a href='/damer/irayol'>irayol</a></li><li><a href='/damer/iria'>iria</a></li><li><a href='/damer/iriampo'>iriampo</a></li><li><a href='/damer/iribú'>iribú</a></li><li><a href='/damer/irigote'>irigote</a></li></ul></div>
+</div>
+</div>
+</div>
+</div>
+<div data-nosnippet class="clearfix" id="main">
+    <div data-nosnippet class="cog--mq mq-main">
+
+            <section class="section section--secondary o-section--large">
+  <div data-nosnippet class="container">
+
+    <h2 class="section__title" data-aos="fade-up" data-aos-offset="50" data-aos-delay="200" data-aos-duration="1000">
+      <span class="divider__title"></span>
+      También le interesará
+    </h2>
+
+    <div data-nosnippet class="row">
+
+      <div data-nosnippet class="col-xs-12 col-md-6 col-lg-3"
+           data-aos="fade-up"
+           data-aos-offset="150"
+           data-aos-delay="400"
+           data-aos-duration="800">
+          <div data-nosnippet class="views-element-container">
+<div data-nosnippet class="js-view-dom-id-14572dd455b88d355b488c1631d66106274028211d5ea51cf38b62e6efe26db7 vista">
+    
+    
+    
+
+    
+    
+    
+
+    
+
+  
+
+<div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/noticia/la-asociacion-de-academias-de-la-lengua-espanola-celebra-su-70o-aniversario-bajo-la">70 AÑOS DE ASALE</a></p>
+
+      <div data-nosnippet class="block-news__img img">
+      <a target="_self" title="Actos de celebración del 70 aniversario" href="/noticia/la-asociacion-de-academias-de-la-lengua-espanola-celebra-su-70o-aniversario-bajo-la">
+        <img class="b-lazy"
+             src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+             data-src="/sites/default/files/styles/tambien_interesa/public/2021-12/70%20anos%20asale.jpg?itok=kU8Y2JlT"
+             alt="Los reyes de España han presidido en el salón de actos de la RAE el solemne acto institucional conmemorativo del septuagésimo aniversario de la Asociación de Academias de la Lengua Española (ASALE). Foto: RAE. " />
+      </a>
+    </div>
+  
+      <span class="news__date">
+      
+    </span>
+  
+  <p class="block-news__title u-text-brandsecondary">
+    <a target="_self" title="Actos de celebración del 70 aniversario" href="/noticia/la-asociacion-de-academias-de-la-lengua-espanola-celebra-su-70o-aniversario-bajo-la">
+      Actos de celebración del 70 aniversario
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+
+  
+
+<div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/obras-academicas/clasicos-asale">Clásicos ASALE</a></p>
+
+      <div data-nosnippet class="block-news__img img">
+      <a target="_self" title="Conozca los títulos de toda la colección" href="/obras-academicas/clasicos-asale">
+        <img class="b-lazy"
+             src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+             data-src="/sites/default/files/styles/tambien_interesa/public/imagenes/articulos/Foto_La_Voz_de_Galicia_1_1.png?itok=nG30FJfh"
+             alt="Nuevos títulos de la colección Clásicos ASALE  " />
+      </a>
+    </div>
+  
+      <span class="news__date">
+      
+    </span>
+  
+  <p class="block-news__title u-text-brandsecondary">
+    <a target="_self" title="Conozca los títulos de toda la colección" href="/obras-academicas/clasicos-asale">
+      Conozca los títulos de toda la colección
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+
+        
+
+    
+    
+
+    
+</div>
+</div>
+
+      </div>
+
+
+      <div data-nosnippet class="col-xs-12 col-md-6 col-lg-8 u-border-left"
+           data-aos="fade-up"
+           data-aos-offset="150"
+           data-aos-delay="400"
+           data-aos-duration="800">
+          <div data-nosnippet class="views-element-container">
+<div data-nosnippet class="js-view-dom-id-2ede9813d48a5ef635d04469e49851a1d0474cfb5f832f321295615630d32cd1 vista">
+    
+    
+    
+
+    
+    
+    
+
+    
+<div data-nosnippet class="row">
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/lexicografia" hreflang="es">Lexicografía</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Cuarta convocatoria del Programa ASALE de becas de formación y colaboración destinado a las academias de la Asociación de Academias de la Lengua Española (ASALE) " href="/noticia/cuarta-convocatoria-del-programa-asale-de-becas-de-formacion-y-colaboracion-destinado-las">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/imagenes/articulos/centro_de_estudios_RAE_serrano.jpg?h=c9f93661&amp;itok=zfPMAJv-"
+               alt="Sede de la Escuela de Lexicografía (Serrano, 187-189) en Madrid (foto: RAE)">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2025-05-27T12:00:00Z">27 de Mayo de 2025</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Cuarta convocatoria del Programa ASALE de becas de formación y colaboración destinado a las academias de la Asociación de Academias de la Lengua Española (ASALE) " href="/noticia/cuarta-convocatoria-del-programa-asale-de-becas-de-formacion-y-colaboracion-destinado-las">
+      <span>Cuarta convocatoria del Programa ASALE de becas de formación y colaboración destinado a las academias de la Asociación de Academias de la Lengua Española (ASALE) </span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/academicos" hreflang="es">Académicos</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Carlos Martini, nuevo miembro de número de la Academia Paraguaya de la Lengua Española" href="/noticia/carlos-martini-nuevo-miembro-de-numero-de-la-academia-paraguaya-de-la-lengua-espanola">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/2021-11/Sede_APARLE.jpg?h=9e499333&amp;itok=BhYtrdjy"
+               alt="Sede de la Academia Paraguaya de la Lengua Española">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2025-01-13T12:00:00Z">13 de Enero de 2025</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Carlos Martini, nuevo miembro de número de la Academia Paraguaya de la Lengua Española" href="/noticia/carlos-martini-nuevo-miembro-de-numero-de-la-academia-paraguaya-de-la-lengua-espanola">
+      <span>Carlos Martini, nuevo miembro de número de la Academia Paraguaya de la Lengua Española</span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/obituarios" hreflang="es">Obituarios</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Fallece Tarsicio Herrera Zapién, miembro de la Academia Mexicana de la Lengua" href="/noticia/fallece-tarsicio-herrera-zapien-miembro-de-la-academia-mexicana-de-la-lengua">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/imagenes/academicos/Tarsicio_Herrera_Sapien_www.cultura.gob_.mx_.jpg?h=c9f93661&amp;itok=XE1zuFdY"
+               alt="Tarsicio Herrera Zapién, miembro de número de la Academia Mexicana de la Lengua. Foto: Secretaría de Cultura.">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2026-02-05T12:00:00Z">5 de Febrero de 2026</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Fallece Tarsicio Herrera Zapién, miembro de la Academia Mexicana de la Lengua" href="/noticia/fallece-tarsicio-herrera-zapien-miembro-de-la-academia-mexicana-de-la-lengua">
+      <span>Fallece Tarsicio Herrera Zapién, miembro de la Academia Mexicana de la Lengua</span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/academicos" hreflang="es">Académicos</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Félix Julio Alfonso López ingresa en la Academia Cubana de la Lengua" href="/noticia/felix-julio-alfonso-lopez-ingresa-en-la-academia-cubana-de-la-lengua">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/2026-02/F%C3%A9lix%20Julio%20Alfonso%20L%C3%B3pez_0.jpg?h=8b436e18&amp;itok=6lYXMiAr"
+               alt="Félix Julio Alfonso López">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2026-02-04T12:00:00Z">4 de Febrero de 2026</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Félix Julio Alfonso López ingresa en la Academia Cubana de la Lengua" href="/noticia/felix-julio-alfonso-lopez-ingresa-en-la-academia-cubana-de-la-lengua">
+      <span>Félix Julio Alfonso López ingresa en la Academia Cubana de la Lengua</span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+  </div>
+
+        
+
+    
+    
+
+    
+</div>
+</div>
+
+      </div>
+
+
+    </div>
+  </div>
+</section>
+
+            <section class="section o-section--medium">
+
+  <div data-nosnippet class="container">
+    <div data-nosnippet class="u-text-center">
+
+      <div data-nosnippet class="btn btn-up" data-aos="fade-up" data-aos-offset="50" data-aos-delay="200" data-aos-duration="1000">
+        <a href="#main" class="ancla">
+          <svg class="icon icon--small icon-black">
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-up"></use>
+          </svg>
+          <p class="btn__text">Arriba</p>
+        </a>
+      </div>
+
+    </div>
+  </div>
+
+</section>
+
+    </div>
+  </div>
+
+  
+  <footer id="footer" class="footer">
+  <div data-nosnippet class="container">
+    <div data-nosnippet class="pre-footer">
+
+      <p class="footer-privacidad">
+        REAL ACADEMIA ESPAÑOLA. Finalidades: Recopilación de información lingüística para la investigación, desarrollo, proyección y buen uso de la lengua española en el ámbito de la IA (proyecto LEIA). Derechos: tiene derecho a acceder, rectificar y suprimir sus datos, así como a otros derechos como se explica en la información adicional y detallada que se puede consultar en nuestra 
+        <span class="privacidad-link privacidad-link--inverse"><a href="/politica-de-privacidad-y-proteccion-de-los-datos-personales" target="_blank">política de privacidad</a>.</span>
+      </p>
+
+    </div>
+
+    <div data-nosnippet class="sub-footer">
+      <div data-nosnippet class="sub-footer__social">
+        <a title="Síganos en X" href="https://x.com/RAEinforma" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en X</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#twitter"></use>
+    </svg>
+</a>
+<a title="Síganos en Facebook"  href="https://www.facebook.com/RAE/" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en Facebook</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#facebook"></use>
+    </svg>
+</a>
+<a title="Visite nuestro Instagram" href="https://www.instagram.com/laraeinforma/" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Visite nuestro Instagram</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#instagram"></use>
+    </svg>
+</a>
+<a title="Síganos en TikTok" href="https://www.tiktok.com/@rae.informa" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en TikTok</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#tiktok"></use>
+    </svg>
+</a>
+<a title="Visite nuestras galerías" href="https://www.flickr.com/photos/raeinforma" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Visite nuestras galerías</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#flicker"></use>
+    </svg>
+</a>
+<a title="Síganos en Youtube" href="https://www.youtube.com/user/RAEInforma" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en Youtube</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#youtube"></use>
+    </svg>
+</a>
+
+<a title="Escuche nuestras listas de música" href="https://open.spotify.com/user/u0gt78txho8qqa5m843kkvxy2" rel="noopener" target="_blank">
+  <svg class="icon icon--medium">
+    <title>Escuche nuestras listas de música</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#spoty"></use>
+  </svg>
+</a>
+
+<a title="Síganos en Souncloud" href="https://soundcloud.com/real-academia-espanola" rel="noopener" target="_blank">
+  <svg class="icon icon--medium">
+    <title>Síganos en Soundcloud</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#soundcloud"></use>
+  </svg>
+</a>
+
+<a title="Contacte con nosotros" href="/contacto-rae">
+	<svg class="icon icon--medium">
+		<title>Contacte con nosotros</title>
+		<use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#email"></use>
+	</svg>
+</a>
+
+      </div>
+
+      <div data-nosnippet class="sub-footer__link">
+        <a title="Visitar Fundación pro-RAE" href="/fundacion">Fundación pro-Rae</a>
+        <a title="Visitar web ASALE" href="https://www.asale.org/" rel="noopener" target="_blank">Asale</a>
+      </div>
+
+
+      <p class="footer__text">
+        Felipe IV, 5 - 28014 Madrid - Teléfono:
+        <a title="Teléfono contacto" href="tel:34914201478">+34 91 420 14 78</a>
+        <span class="ml-1 d-inline-block">
+          © Real Academia Española, 2019
+        </span>
+      </p>
+
+      
+
+<nav role="navigation" aria-labelledby="block-piedepagina" id="block-piedepagina" class="block block-menu navigation block-system-menublock menu--footer">
+      
+        
+
+                        <ul class="footer-list">
+                            <li class="footer-list__item">
+                <a href="https://rae.whistlelink.com" target="_blank">Canal del informante</a>
+                            </li>
+                </ul>
+    
+
+
+  </nav>
+
+    </div>
+
+  </div>
+</footer>
+
+<div data-nosnippet class="search-full-container">
+  <span class="menu-buttom__close">
+  <svg class="icon icon--xsmall icon-black">
+    <title>cerrar</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#close"></use>
+  </svg>
+</span>
+  <div data-nosnippet class="container">
+
+    <div data-nosnippet class="header__logo">
+      <div data-nosnippet class="img">
+        <a href="/" title="Inicio - Real Academia Española" rel="home" class="site-logo">
+          <svg class="icon icon-logo">
+            <title>Logo RAE</title>
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#logo-rae"></use>
+          </svg>
+        </a>
+      </div>
+    </div>
+    <div data-nosnippet class="row justify-content-center">
+      <div data-nosnippet class="col-12 col-md-8">
+        <h2 class="search__title">Buscador general de la RAE</h2>
+
+        <form class="search-block-form" data-drupal-selector="search-block-form" action="/search/node" method="get" id="search-block-form" accept-charset="UTF-8">
+  <div data-nosnippet class="js-form-item form-item js-form-type-search form-type-search js-form-item-keys form-item-keys form-no-label">
+      <label for="edit-keys" class="visually-hidden">Search</label>
+        <input title="Escriba lo que quiere buscar." placeholder="Buscar en la web" data-drupal-selector="edit-keys" type="search" id="edit-keys" name="keys" value="" size="15" maxlength="128" class="form-search" />
+
+        </div>
+<div data-nosnippet data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions"><input alt="Buscar en la web" data-drupal-selector="edit-submit" type="image" id="edit-submit" name="op" src="/themes/custom/front/src/assets/images/lupa.svg" class="image-button js-form-submit form-submit" />
+</div>
+
+</form>
+
+      </div>
+    </div>
+  </div>
+</div>
+
+<div data-nosnippet class="dle-full-container">
+  <span class="menu-buttom__close">
+  <svg class="icon icon--xsmall icon-black">
+    <title>cerrar</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#close"></use>
+  </svg>
+</span>
+  <div data-nosnippet class="contenedor-full">
+
+    <div data-nosnippet class="container">
+      <div data-nosnippet class="row justify-content-between">
+
+        <div data-nosnippet class="col-xs-12 col-lg-7">
+          <div data-nosnippet class="diccionarios-container">
+            <h2 class="diccionarios-container__title">Diccionarios</h2>
+            <form class="diccionarios-form" data-drupal-selector="diccionarios-form" action="/" method="post" id="diccionarios-form" accept-charset="UTF-8">
+  <div data-nosnippet id="edit-diccionario"><div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dle" type="radio" id="edit-diccionario-dle" name="diccionario" value="dle" checked="checked" class="form-radio" />
+
+        <label for="edit-diccionario-dle" class="option">Diccionario de la lengua española</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dpd" type="radio" id="edit-diccionario-dpd" name="diccionario" value="dpd" class="form-radio" />
+
+        <label for="edit-diccionario-dpd" class="option">Diccionario panhispánico de dudas</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dpej" type="radio" id="edit-diccionario-dpej" name="diccionario" value="dpej" class="form-radio" />
+
+        <label for="edit-diccionario-dpej" class="option">Diccionario panhispánico del español jurídico</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dhle" type="radio" id="edit-diccionario-dhle" name="diccionario" value="dhle" class="form-radio" />
+
+        <label for="edit-diccionario-dhle" class="option">Diccionario histórico de la lengua española</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-damer" type="radio" id="edit-diccionario-damer" name="diccionario" value="damer" class="form-radio" />
+
+        <label for="edit-diccionario-damer" class="option">Diccionario de americanismos</label>
+      </div>
+</div>
+<fieldset data-drupal-selector="edit-caja" id="edit-caja" class="form-item js-form-wrapper form-wrapper">
+      <legend>
+    <span class="fieldset-legend"></span>
+  </legend>
+  <div data-nosnippet class="fieldset-wrapper">
+            <div data-nosnippet class="js-form-item form-item js-form-type-textfield form-type-textfield js-form-item-termino form-item-termino form-no-label">
+        <input aria-label="Término" data-drupal-selector="edit-termino" type="text" id="edit-termino" name="termino" value="" size="60" maxlength="128" placeholder="Escriba el término" class="form-text required" required="required" aria-required="true" />
+
+        </div>
+<input class="icon--small image-button js-form-submit form-submit" alt="Escriba el término" data-drupal-selector="edit-submit" type="image" id="edit-submit--2" name="op" src="/themes/custom/front/src/assets/images/lupa.svg" />
+
+          </div>
+</fieldset>
+<div data-nosnippet class="logo"><div data-nosnippet data-drupal-selector="edit-lacaixa-modal" data-drupal-states="{&quot;visible&quot;:[{&quot;:input[name=\u0022diccionario\u0022]&quot;:{&quot;value&quot;:&quot;dle&quot;}}]}" id="edit-lacaixa-modal" class="js-form-wrapper form-wrapper"><a title="Fundación “la Caixa”" rel="noopener" target="_blank" href="https://fundacionlacaixa.org/es/home"><img src="/themes/custom/front/src/assets/svg/logo-fundacion-caixa.svg" alt="Logo Obra social “la Caixa”"></a></div>
+</div><input autocomplete="off" data-drupal-selector="form-mzbxidgjhgto6qa9v8eo5idw8kx4jlyyoeaom28v7p4" type="hidden" name="form_build_id" value="form-mzBXIDGJHgTO6qA9v8eo5iDW8Kx4jLyYoEAom28V7P4" />
+<input data-drupal-selector="edit-diccionarios-form" type="hidden" name="form_id" value="diccionarios_form" />
+<div data-nosnippet data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions--3"></div>
+
+</form>
+
+          </div>
+        </div>
+        <div data-nosnippet class="col-xs-12 col-lg-4">
+          <div data-nosnippet class="dudas-container">
+            <h2 class="dudas-container__title">Dudas rápidas</h2>
+            <form class="dudas-form-modal" data-drupal-selector="dudas-form-modal" action="/" method="post" id="dudas-form-modal" accept-charset="UTF-8">
+  <fieldset data-drupal-selector="edit-caja-dudas-modal" id="edit-caja-dudas-modal" class="form-item js-form-wrapper form-wrapper">
+      <legend>
+    <span class="fieldset-legend"></span>
+  </legend>
+  <div data-nosnippet class="fieldset-wrapper">
+            <div data-nosnippet class="js-form-item form-item js-form-type-textfield form-type-textfield js-form-item-duda-modal form-item-duda-modal form-no-label">
+        <input aria-label="Término" data-drupal-selector="edit-duda-modal" type="text" id="edit-duda-modal" name="duda_modal" value="" size="60" maxlength="128" placeholder="Escriba las palabras clave" class="form-text required" required="required" aria-required="true" />
+
+        </div>
+<input class="icon--small image-button js-form-submit form-submit" alt="Buscar duda" data-drupal-selector="edit-submit-modal" type="image" id="edit-submit-modal" name="op" src="/themes/custom/front/src/assets/images/lupa.svg" />
+
+          </div>
+</fieldset>
+<input autocomplete="off" data-drupal-selector="form-edezrmi8ug6dktult8r9ktp1tu0hqxuc-frp39jqkne" type="hidden" name="form_build_id" value="form-edEzrMi8Ug6dKtULt8r9kTp1Tu0hQxUc_Frp39JQKnE" />
+<input data-drupal-selector="edit-dudas-form-modal" type="hidden" name="form_id" value="dudas_form_modal" />
+<div data-nosnippet data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions--5"></div>
+
+</form>
+
+          </div>
+        </div>
+      </div>
+
+      <div data-nosnippet class="recursos-container">
+        <h2 class="title__medium text-center mb-7">
+          Otros Recursos
+          <svg class="icon icon--xsmall icon-black">
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#plus"></use>
+          </svg>
+          <svg class="icon icon--xsmall icon-black hidden">
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#menos"></use>
+          </svg>
+        </h2>
+        <div data-nosnippet class="lista-recursos-container">
+          
+
+
+    
+          <ul class="lista-recursos" >
+    
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Diccionarios</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://dle.rae.es/">Diccionario de la lengua española</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/dpd/">Diccionario panhispánico de dudas</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://dpej.rae.es/">Diccionario panhispánico del español jurídico</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="/dhle">Diccionario histórico de la lengua española</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.asale.org/damer/">Diccionario de americanismos</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/diccionario-estudiante/" title="Diccionario del estudiante">Diccionario del estudiante</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/tdhle/" title="Tesoro de diccionarios históricos de la lengua">Tesoro de diccionarios históricos de la lengua</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/DA.html">Diccionario de autoridades</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://apps.rae.es/ntlle/SrvltGUISalirNtlle">Nuevo tesoro lexicográfico</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/ntllet/SrvltGUILoginNtlletPub">Mapa de diccionarios</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/DH1936.html">Diccionario histórico (1933-1936)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/DH.html">Diccionario histórico (1960-1996)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/drae2001/">Diccionario de la lengua española (2001)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/desen/">Diccionario esencial (2006)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/formulario-de-la-unidad-interactiva-del-diccionario" title="Envíe las propuestas y sugerencias externas relacionadas con el «Diccionario de la lengua española»">Unidad Interactiva del Diccionario (UNIDRAE)</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Banco de datos</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/corpes/">CORPES XXI</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/CNDHE/">CDH</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://corpus.rae.es/creanet.html">CREA</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/crea-anotado/" title="CREA anotado">CREA anotado</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://corpus.rae.es/cordenet.html">CORDE</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/fichero.html">Fichero general</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.asale.org/corpus-asale/">Corpus ASALE</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Gramática</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://aplica.rae.es/grweb/cgi-bin/buscar.cgi">Nueva gramática de la lengua española</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/gtg/">Glosario de términos gramaticales</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/sites/default/files/Gramatica_RAE_1771_reducida.pdf">Primera gramática</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/gram%C3%A1tica-b%C3%A1sica/" title="Nueva gramática básica de la lengua española">Nueva gramática básica de la lengua española</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Ortografía</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://aplica.rae.es/orweb/cgi-bin/buscar.cgi">Ortografía 2010</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="/sites/default/files/Ortografia_RAE_1741_reducida.pdf">Primera ortografía</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/ortograf%C3%ADa-b%C3%A1sica/" title="Ortografía básica de la lengua española">Ortografía básica de la lengua española</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Biblioteca</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca/biblioteca-academica">Biblioteca académica</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca/legado-antonio-rodriguez-monino-y-maria-brey">Legado Rodríguez-Moñino</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca/legado-damaso-alonso">Legado Dámaso Alonso</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca-digital" title="Biblioteca Digital">Biblioteca Digital</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Archivo</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://archivo.rae.es/">Fondo institucional</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://archivo.rae.es/index.php/coleccion-de-autografos-de-pedro-antonio-de-alarcon">Colección P. A. de Alarcón</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://archivo.rae.es/zorrilla/">Zorrilla</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/manuscritos-para-la-segunda-edicion-del-diccionario-de-autoridades">2.ª edición del «Diccionario de autoridades»</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://archivo.rae.es/fichero-de-hilo">Fichero de hilo</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Boletines</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://revistas.rae.es/bilrae/">BILRAE</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://revistas.rae.es/brae">BRAE</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span title="Recursos académicos de apoyo para el lenguaje claro">Lenguaje claro</span>
+          </div>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Enclave</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://enclavedeciencia.rae.es/inicio">Enclave de Ciencia</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Enlaces externos</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://asines.org/">Atlas sintáctico del español</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/dhecan.html">Diccionario Histórico del Español de Canarias</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/CORLEXIN.html">Corpus Léxico de Inventarios</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://lla.unileon.es/" title="Léxico leonés actual">Léxico leonés actual</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+    
+  </ul>
+  
+
+
+        </div>
+      </div>
+
+
+    </div>
+
+  </div>
+</div>
+
+</div>
+
+  </div>
+
+      
+
+    </div>
+
+    
+
+
+  <script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script src="/sites/default/files/js/js_7hSOT9HVKxMvGlrclR4TDcqOUtAR-0e88Vkq_P_PROE.js"></script>\n<script src="/damer/js/20210406.js"></script>
+<!--[if IE]>
+<style>
+#deletex{ display:none;}
+</style>
+<![endif]-->
+</body>
+<script>
+window.cat='EXTERNO';window.acc='www.asale.org/damer/ir';window.eti='https://www.google.com/';
+</script>
+</html>

--- a/tests/cogs/damer_sample_htmls/living.html
+++ b/tests/cogs/damer_sample_htmls/living.html
@@ -1,0 +1,1358 @@
+<!DOCTYPE html>
+<html lang="es">
+<head><noscript><style>form.antibot * :not(.antibot-message) { display: none !important; }</style></noscript>
+<link rel="preload" href="/sites/default/files/css/css_2toHNXfbnPicu5GM0gX9NZ5orfKOc_JkPXeCbZqaWws.css" as="style">
+<link rel="preload" href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&amp;display=swap" as="style">
+<link rel="preload" href="https://fonts.googleapis.com/css2?family=Merriweather:wght@700&amp;display=swap" as="style">
+<link rel="preload" href="/sites/default/files/css/css_MKU0IOMhjZnRGgSeMxmlSpwNVcEMZOFPTb3EZkC-BVI.css" as="style">
+<link rel="preload" href="/sites/default/files/js/js_7hSOT9HVKxMvGlrclR4TDcqOUtAR-0e88Vkq_P_PROE.js" as="script">
+<link rel="preload" href="/damer/css/20201019.css" as="style">
+<link rel="preload" href="/damer/js/20210406.js" as="script">
+<link rel="preload" href="/themes/custom/front/assets/fonts/lato/lato-bold-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/lato/lato-regular-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/merriweather/merriweather-black-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/merriweather/merriweather-light-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/merriweather/merriweather-regular-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="canonical" href="https://www.asale.org/damer/living"/>
+<title>living | Diccionario de americanismos | ASALE</title>
+<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="I. 1. Cu , Bo , Ch , Py. Juego de sofá y sillones de una sala de estar. ■ a. ǁ comedor. m. Ni , Cu , Bo , Ch , Py , Ar. Habitación de una casa en la que se hace la vida social."/>
+<meta name="keywords" content="living, definición de living, significado de living, ASALE, RAE"/>
+<meta name="author" content="ASALE"/>
+<meta name="robots" content="index,follow"/>
+<meta name="rating" content="safe for kids"/>
+<meta name="rights" content="Asociación de Academias de la Lengua Española © Todos los derechos reservados"/>
+<meta name="author" content="ASALE">
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:site" content="\@ASALEinforma"/>
+<meta name="twitter:url" content="https://www.asale.org/damer/living"/>
+<meta name="twitter:title" content="living | Diccionario de americanismos"/>
+<meta name="twitter:description" content="I. 1. Cu , Bo , Ch , Py. Juego de sofá y sillones de una sala de estar. ■ a. ǁ comedor. m. Ni , Cu , Bo , Ch , Py , Ar. Habitación de una casa en la que se hace la vida social."/>
+<meta name="twitter:image" content="/damer/img/logo-asale.png"/>
+<meta name="twitter:image:alt" content="«Diccionario de americanismos»"/>
+<meta property="article:author" content="https://es-es.facebook.com/asale"/>
+<meta property="og:title" content="living | Diccionario de americanismos"/>
+<meta property="og:type" content="website"/>
+<meta property="og:site_name" content="«Diccionario de americanismos»"/>
+<meta property="og:url" content="https://www.asale.org/damer/living"/>
+<meta property="og:description" content="I. 1. Cu , Bo , Ch , Py. Juego de sofá y sillones de una sala de estar. ■ a. ǁ comedor. m. Ni , Cu , Bo , Ch , Py , Ar. Habitación de una casa en la que se hace la vida social."/>
+<meta property="og:locale" content="es"/>
+<meta property="og:image" content="/damer/img/logo-asale.png"/>
+<meta property="og:image:type" content="image/png"/>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<link rel="shortcut icon" href="/themes/custom/front/favicon.ico" />
+<link rel="mask-icon" href="/themes/custom/front/src/assets/images/favicons/safari-pinned-tab.svg" />
+<link rel="icon" sizes="16x16" href="/themes/custom/front/src/assets/images/favicons/favicon-16x16.png" />
+<link rel="icon" sizes="32x32" href="/themes/custom/front/src/assets/images/favicons/favicon-32x32.png" />
+<link rel="apple-touch-icon" sizes="180x180" href="/themes/custom/front/src/assets/images/favicons/apple-touch-icon.png" />
+<link rel="apple-touch-icon-precomposed" sizes="180x180" href="/themes/custom/front/src/assets/images/favicons/apple-touch-icon.png" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=2, minimum-scale=1, user-scalable=yes" />
+<!--[if lt IE 9]><script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+<script type="application/ld+json">
+[{"@context": "http://schema.org/"},{"@type": ["DefinedTermSet","Book"],"@id": "https://www.asale.org/damer","name": "Diccionario de americanismos RAE - ASALE","image": "https://www.asale.org/damer/img/logo-asale.png","description": "Versión electrónica del «Diccionario de americanismos»."},{"@type": "DefinedTerm","@id": "https://www.asale.org/damer/living","name": "living","description": "I. 1. Cu , Bo , Ch , Py. Juego de sofá y sillones de una sala de estar. ■ a. ǁ comedor. m. Ni , Cu , Bo , Ch , Py , Ar. Habitación de una casa en la que se hace la vida social.","inDefinedTermSet": "https://www.asale.org/damer"}]
+</script><link rel="stylesheet" media="all" href="/sites/default/files/css/css_2toHNXfbnPicu5GM0gX9NZ5orfKOc_JkPXeCbZqaWws.css"/>
+<link rel="stylesheet" media="all" href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&amp;display=swap"/>
+<link rel="stylesheet" media="all" href="https://fonts.googleapis.com/css2?family=Merriweather:wght@700&amp;display=swap"/>
+<link rel="stylesheet" media="all" href="/sites/default/files/css/css_MKU0IOMhjZnRGgSeMxmlSpwNVcEMZOFPTb3EZkC-BVI.css"/>
+<script>window.a2a_config=window.a2a_config||{};a2a_config.callbacks=[];a2a_config.overlays=[];a2a_config.templates={};a2a_config.static_server= "http://www.asale.org/sites/default/files/addtoany/menu/oafg07ee";a2a_config.icon_color = "transparent,#000";</script>
+
+<link rel="stylesheet" media="all" href="/damer/css/20201019.css"/>
+</head>
+<body class="path--node body-sidebars-none alias--noticia-primera-reunion-plenaria-virtual-de-directores-y-presidentes-de-las-academias-de-la-lengua nodetype--noticia logged-out" data-aos-easing="ease" data-aos-duration="400" data-aos-delay="0">
+<div role="main">
+<div class="dialog-off-canvas-main-canvas" data-off-canvas-main-canvas="">
+<div class="page-standard" id="pg__c">
+
+<header id="header" class="header">
+
+  <div class="header__logo">
+    <div class="img">
+                <a href="/" title="Inicio - ASALE" rel="home" class="site-logo">
+            <img src="/themes/custom/asale/assets/images/logo-asale.png" alt="Logo ASALE"/>
+          </a>
+          </div>
+  </div>
+
+  <div class="header-menu-search">
+
+    <nav class="header-menu">
+
+      <div class="main-menu-container">
+        <span class="menu-buttom__close">
+  <svg class="icon icon--xsmall icon-black">
+    <title>cerrar</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#close"></use>
+  </svg>
+</span>
+        
+
+<nav role="navigation" aria-labelledby="block-navegacionprincipalasale" id="block-navegacionprincipalasale" class="block block-menu navigation block-system-menublock menu--main-asale">
+      
+        
+
+
+              <ul class="menu-list main">
+              <li class="menu-list__item" >
+
+                  <div class="parent-item">
+            <a href="/la-asociacion" data-drupal-link-system-path="node/29051">La Asociación</a>
+            <span class="menu-collapse">
+              <svg class="icon icon--xsmall icon-black">
+                <title>Abrir submenu</title>
+                <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-bottom"></use>
+              </svg>
+            </span>
+          </div>
+        
+
+                                <ul>
+              <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/bienvenida" data-drupal-link-system-path="node/31480">Bienvenida</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/presentacion" data-drupal-link-system-path="node/31494">Presentación</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/comision-permanente" data-drupal-link-system-path="node/29478">Comisión Permanente</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/politica-panhispanica" data-drupal-link-system-path="node/31648">Política panhispánica</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/actividad-institucional" data-drupal-link-system-path="node/31515">Actividad institucional</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/biblioteca-de-la-asale" data-drupal-link-system-path="node/31634">Biblioteca de la ASALE</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/conmemoraciones" data-drupal-link-system-path="node/31641">Conmemoraciones</a>
+        
+
+              </li>
+      </ul>
+    
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/academias" data-drupal-link-system-path="academias">Academias</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <div class="parent-item">
+            <a href="/obras" data-drupal-link-system-path="node/29030">Obras</a>
+            <span class="menu-collapse">
+              <svg class="icon icon--xsmall icon-black">
+                <title>Abrir submenu</title>
+                <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-bottom"></use>
+              </svg>
+            </span>
+          </div>
+        
+
+                                <ul>
+              <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/diccionarios" data-drupal-link-system-path="taxonomy/term/100">Diccionarios</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/gramatica" data-drupal-link-system-path="taxonomy/term/101">Gramática</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/ortografia" data-drupal-link-system-path="taxonomy/term/102">Ortografía</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/ediciones-conmemorativas" data-drupal-link-system-path="taxonomy/term/103">Ediciones conmemorativas</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/clasicos-asale" data-drupal-link-system-path="taxonomy/term/337">Clásicos ASALE</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/otras-obras" data-drupal-link-system-path="taxonomy/term/330">Otras obras</a>
+        
+
+              </li>
+      </ul>
+    
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/corpus" data-drupal-link-system-path="node/29037">Corpus</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <div class="parent-item">
+            <a href="/escuela-de-lexicografia" data-drupal-link-system-path="node/29044">Escuela de Lexicografía</a>
+            <span class="menu-collapse">
+              <svg class="icon icon--xsmall icon-black">
+                <title>Abrir submenu</title>
+                <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-bottom"></use>
+              </svg>
+            </span>
+          </div>
+        
+
+                                <ul>
+              <li class="menu-list__item" >
+
+                  <a href="/escuela-de-lexicografia/la-elh" data-drupal-link-system-path="node/32131">La ELH</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/escuela-de-lexicografia/master-de-lexicografia-hispanica-y-correccion-linguistica" data-drupal-link-system-path="node/88530">Máster</a>
+        
+
+              </li>
+      </ul>
+    
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/publicaciones" data-drupal-link-system-path="node/28988">Publicaciones</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/noticias" data-drupal-link-system-path="noticias">Noticias</a>
+        
+
+              </li>
+      </ul>
+    
+
+
+  </nav>
+      </div>
+
+      <ul class="search-block">
+        <li class="menu-list__item link-dle">
+          <svg class="icon icon--tiny icon-white">
+            <title>Recursos</title>
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#diccionarios"></use>
+          </svg>
+          <span class="menu-list__text">Recursos</span>
+        </li>
+        <li class="menu-list__item link-search">
+          <svg class="icon icon--xsmall icon-white">
+            <title>Buscador</title>
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#lupa"></use>
+          </svg>
+        </li>
+        <li class="menu-list__item link-menu">
+          <svg class="icon icon--small icon-white">
+            <title>Menu</title>
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#menu"></use>
+          </svg>
+        </li>
+      </ul>
+
+    </nav>
+  </div>
+</header>
+<div class="container">
+<div class="row">
+<div class="col-xs-12 col-md-8" style="border-right:1px solid #ccc">  
+<div style="margin: 20px 0 10px 0;font-size:2em"><a href="/damer/">Diccionario de americanismos</a></div>
+<div class="form-box-wrapper">
+<div class="form-box"><form action="#" method="post" class="form form-damer" id="formulario"><input size="30" style="border:1px solid #ccc" class="custom-search-box" name="w" id="wq" type="text" value="" placeholder="Escriba aquí la palabra" autocomplete="off" autocapitalize="off"/><input style="margin-left:5px" alt="Buscar" type="image" class="icon icon--xsmall icon-grey" src="/themes/custom/front/src/assets/images/lupa.svg" name="submit"></form></div>
+<div class="addtext"><a style="" href="javascript:addText('á','damer');">á</a><a style="" href="javascript:addText('é','damer');">é</a><a style="" href="javascript:addText('í','damer');">í</a><a style="" href="javascript:addText('ó','damer');">ó</a><a style="" href="javascript:addText('ú','damer');">ú</a><a style="" href="javascript:addText('ü','damer');">ü</a><a style="" href="javascript:addText('ñ','damer');">ñ</a></div>
+</div>
+
+<div class="bloque-txt" id="resultados">
+<entry xmlns="http://www.w3.org/1999/xhtml" header="_living_" key="living" id="SPFRRxXbYx0ASKuCcg9">
+<table class="da4"><tr><td colspan="5" class="da2"><i><span class="da8">living. </span></i><span class="da1">(Voz inglesa).</span></td></tr><tr><td> </td><td class="da7"><span class="da3">I.</span></td><td class="da7"><span class="da3">1.</span></td><td colspan="2" class="da6">m. <i><span class="da5">Cu</span></i><span class="da5">, </span><i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ch</span></i><span class="da5">, </span><i><span class="da5">Py.</span></i><span class="da5"> Juego de sof&#xE1; y sillones de una sala de estar.</span></td></tr><tr><td> </td><td class="da7"><span class="da3">&#x25A0;</span></td><td> </td><td> </td><td> </td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">a. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> comedor.</span><span class="da5"> m. </span><i><span class="da5">Ni</span></i><span class="da5">, </span><i><span class="da5">Cu</span></i><span class="da5">, </span><i><span class="da5">Bo</span></i><span class="da5">, </span><i><span class="da5">Ch</span></i><span class="da5">, </span><i><span class="da5">Py</span></i><span class="da5">, </span><i><span class="da5">Ar.</span></i><span class="da5"> Habitaci&#xF3;n de una casa en la que se hace la vida social.</span></td></tr></table>
+</entry>
+<p class="o"><center><i><span class="d7">Diccionario de americanismos © 2010<br/>Asociación de Academias de la Lengua Española © Todos los derechos reservados</span></i></center></p><div class="compartir"><a title="Compartir en Facebook" class="resp-sharing-button__link" href="https://facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fliving" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--facebook resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M18.77 7.46H14.5v-1.9c0-.9.6-1.1 1-1.1h3V.5h-4.33C10.24.5 9.5 3.44 9.5 5.32v2.15h-3v4h3v12h5v-12h3.85l.42-4z"/></svg></div></div></a>
+<a title="Compartir en Twitter" class="resp-sharing-button__link" href="https://twitter.com/intent/tweet/?text=living - Diccionario de americanismos&url=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fliving" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--twitter resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M23.44 4.83c-.8.37-1.5.38-2.22.02.93-.56.98-.96 1.32-2.02-.88.52-1.86.9-2.9 1.1-.82-.88-2-1.43-3.3-1.43-2.5 0-4.55 2.04-4.55 4.54 0 .36.03.7.1 1.04-3.77-.2-7.12-2-9.36-4.75-.4.67-.6 1.45-.6 2.3 0 1.56.8 2.95 2 3.77-.74-.03-1.44-.23-2.05-.57v.06c0 2.2 1.56 4.03 3.64 4.44-.67.2-1.37.2-2.06.08.58 1.8 2.26 3.12 4.25 3.16C5.78 18.1 3.37 18.74 1 18.46c2 1.3 4.4 2.04 6.97 2.04 8.35 0 12.92-6.92 12.92-12.93 0-.2 0-.4-.02-.6.9-.63 1.96-1.22 2.56-2.14z"/></svg></div></div></a>
+<a title="Compartir por correo electrónico" class="resp-sharing-button__link" href="/cdn-cgi/l/email-protection#9da2eee8fff7f8fee9a0f1f4ebf4f3fabdb0bdd9f4fefef4f2f3fceff4f2bdf9f8bdfcf0f8eff4fefcf3f4eef0f2eebbfff2f9e4a0f5e9e9edeea7b2b2eaeaeab3fceefcf1f8b3f2effab2f9fcf0f8efb2f1f4ebf4f3fab8addcb8addcd4b3bdacb3bddee8bdb1bddff2bdb1bddef5bdb1bdcde4b3bdd7e8f8faf2bdf9f8bdeef2fb5e3cbde4bdeef4f1f1f2f3f8eebdf9f8bde8f3fcbdeefcf1fcbdf9f8bdf8eee9fcefb3bd7f0b3dbdfcb3bd5a1cbdfef2f0f8f9f2efb3bdf0b3bdd3f4bdb1bddee8bdb1bddff2bdb1bddef5bdb1bdcde4bdb1bddcefb3bdd5fcfff4e9fcfef45e2ef3bdf9f8bde8f3fcbdfefceefcbdf8f3bdf1fcbdece8f8bdeef8bdf5fcfef8bdf1fcbdebf4f9fcbdeef2fef4fcf1b3" target="_self" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--email resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M22 4H2C.9 4 0 4.9 0 6v12c0 1.1.9 2 2 2h20c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zM7.25 14.43l-3.5 2c-.08.05-.17.07-.25.07-.17 0-.34-.1-.43-.25-.14-.24-.06-.55.18-.68l3.5-2c.24-.14.55-.06.68.18.14.24.06.55-.18.68zm4.75.07c-.1 0-.2-.03-.27-.08l-8.5-5.5c-.23-.15-.3-.46-.15-.7.15-.22.46-.3.7-.14L12 13.4l8.23-5.32c.23-.15.54-.08.7.15.14.23.07.54-.16.7l-8.5 5.5c-.08.04-.17.07-.27.07zm8.93 1.75c-.1.16-.26.25-.43.25-.08 0-.17-.02-.25-.07l-3.5-2c-.24-.13-.32-.44-.18-.68s.44-.32.68-.18l3.5 2c.24.13.32.44.18.68z"/></svg></div></div></a>
+<a title="Compartir en WhatsApp" class="resp-sharing-button__link" href="whatsapp://send?text=living - Diccionario de americanismos%20https%3A%2F%2Fwww.asale.org%2Fdamer%2Fliving" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--whatsapp resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20.1 3.9C17.9 1.7 15 .5 12 .5 5.8.5.7 5.6.7 11.9c0 2 .5 3.9 1.5 5.6L.6 23.4l6-1.6c1.6.9 3.5 1.3 5.4 1.3 6.3 0 11.4-5.1 11.4-11.4-.1-2.8-1.2-5.7-3.3-7.8zM12 21.4c-1.7 0-3.3-.5-4.8-1.3l-.4-.2-3.5 1 1-3.4L4 17c-1-1.5-1.4-3.2-1.4-5.1 0-5.2 4.2-9.4 9.4-9.4 2.5 0 4.9 1 6.7 2.8 1.8 1.8 2.8 4.2 2.8 6.7-.1 5.2-4.3 9.4-9.5 9.4zm5.1-7.1c-.3-.1-1.7-.9-1.9-1-.3-.1-.5-.1-.7.1-.2.3-.8 1-.9 1.1-.2.2-.3.2-.6.1s-1.2-.5-2.3-1.4c-.9-.8-1.4-1.7-1.6-2-.2-.3 0-.5.1-.6s.3-.3.4-.5c.2-.1.3-.3.4-.5.1-.2 0-.4 0-.5C10 9 9.3 7.6 9 7c-.1-.4-.4-.3-.5-.3h-.6s-.4.1-.7.3c-.3.3-1 1-1 2.4s1 2.8 1.1 3c.1.2 2 3.1 4.9 4.3.7.3 1.2.5 1.6.6.7.2 1.3.2 1.8.1.6-.1 1.7-.7 1.9-1.3.2-.7.2-1.2.2-1.3-.1-.3-.3-.4-.6-.5z"/></svg></div></div></a>
+<a title="Compartir en Telegram" class="resp-sharing-button__link" href="https://telegram.me/share/url?text=living - Diccionario de americanismos&url=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fliving" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--telegram resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M.707 8.475C.275 8.64 0 9.508 0 9.508s.284.867.718 1.03l5.09 1.897 1.986 6.38a1.102 1.102 0 0 0 1.75.527l2.96-2.41a.405.405 0 0 1 .494-.013l5.34 3.87a1.1 1.1 0 0 0 1.046.135 1.1 1.1 0 0 0 .682-.803l3.91-18.795A1.102 1.102 0 0 0 22.5.075L.706 8.475z"/></svg></div></div></a>
+<a title="Compartir en Pinterest" class="resp-sharing-button__link" href="https://pinterest.com/pin/create/button/?url=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fliving&media=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fliving&description=I. 1. Cu , Bo , Ch , Py. Juego de sofá y sillones de una sala de estar. ■ a. ǁ comedor. m. Ni , Cu , Bo , Ch , Py , Ar. Habitación de una casa en la que se hace la vida social." target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--pinterest resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.14.5C5.86.5 2.7 5 2.7 8.75c0 2.27.86 4.3 2.7 5.05.3.12.57 0 .66-.33l.27-1.06c.1-.32.06-.44-.2-.73-.52-.62-.86-1.44-.86-2.6 0-3.33 2.5-6.32 6.5-6.32 3.55 0 5.5 2.17 5.5 5.07 0 3.8-1.7 7.02-4.2 7.02-1.37 0-2.4-1.14-2.07-2.54.4-1.68 1.16-3.48 1.16-4.7 0-1.07-.58-1.98-1.78-1.98-1.4 0-2.55 1.47-2.55 3.42 0 1.25.43 2.1.43 2.1l-1.7 7.2c-.5 2.13-.08 4.75-.04 5 .02.17.22.2.3.1.14-.18 1.82-2.26 2.4-4.33.16-.58.93-3.63.93-3.63.45.88 1.8 1.65 3.22 1.65 4.25 0 7.13-3.87 7.13-9.05C20.5 4.15 17.18.5 12.14.5z"/></svg></div></div></a>
+<a title="Compartir en LinkedIn" class="resp-sharing-button__link" href="https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fliving&title=living - Diccionario de americanismos&summary=I. 1. Cu , Bo , Ch , Py. Juego de sofá y sillones de una sala de estar. ■ a. ǁ comedor. m. Ni , Cu , Bo , Ch , Py , Ar. Habitación de una casa en la que se hace la vida social.&source=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fliving" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--linkedin resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
+<svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M6.5 21.5h-5v-13h5v13zM4 6.5C2.5 6.5 1.5 5.3 1.5 4s1-2.4 2.5-2.4c1.6 0 2.5 1 2.6 2.5 0 1.4-1 2.5-2.6 2.5zm11.5 6c-1 0-2 1-2 2v7h-5v-13h5V10s1.6-1.5 4-1.5c3 0 5 2.2 5 6.3v6.7h-5v-7c0-1-1-2-2-2z"/></svg></div></div></a></div></div>
+</div>
+<div data-nosnippet class="col-xs-12 col-md-4 bloque-txt">
+<h2 class="ayuda">Más información</h2>
+<div class="view-node-navigation"><ul class="menu"><li class="leaf d0"><a target="_blank" title="Prólogo de la obra" class="tooltip" href="https://www.asale.org/sites/default/files/Prologo_Diccionario_de_americanismos.pdf">Prólogo</a> de la obra</li><li class="leaf d0"><a target="_blank" title="Preliminares (abreviaturas) de la obra" class="tooltip" href="https://www.asale.org/sites/default/files/Abreviaturas_del_DA.pdf">Preliminares</a> (abreviaturas) de la obra</li></ul></div>
+
+    
+<div><h2 class="ayuda">Rueda de palabras</h2>
+<div>
+<ul class='rueda'><li><a href='/damer/litrero'>litrero</a></li><li><a href='/damer/litro'>litro</a></li><li><a href='/damer/liudar'>liudar</a></li><li><a href='/damer/liuta'>liuta</a></li><li><a href='/damer/liviana'>liviana</a></li><li><a href='/damer/liviano'>liviano</a></li><li><a href='/damer/livin'>livin</a></li><li><b>living</b></li><li><a href='/damer/liza'>liza</a></li><li><a href='/damer/lizadero'>lizadero</a></li><li><a href='/damer/lizo'>lizo</a></li><li><a href='/damer/llaboa'>llaboa</a></li><li><a href='/damer/llaca'>llaca</a></li><li><a href='/damer/llacar'>llacar</a></li><li><a href='/damer/llachapa'>llachapa</a></li></ul></div>
+</div>
+</div>
+</div>
+</div>
+<div data-nosnippet class="clearfix" id="main">
+    <div data-nosnippet class="cog--mq mq-main">
+
+            <section class="section section--secondary o-section--large">
+  <div data-nosnippet class="container">
+
+    <h2 class="section__title" data-aos="fade-up" data-aos-offset="50" data-aos-delay="200" data-aos-duration="1000">
+      <span class="divider__title"></span>
+      También le interesará
+    </h2>
+
+    <div data-nosnippet class="row">
+
+      <div data-nosnippet class="col-xs-12 col-md-6 col-lg-3"
+           data-aos="fade-up"
+           data-aos-offset="150"
+           data-aos-delay="400"
+           data-aos-duration="800">
+          <div data-nosnippet class="views-element-container">
+<div data-nosnippet class="js-view-dom-id-02a2d65813f4ad19486655be44ae3d013bf874ea18cdb029038d81b8f502454b vista">
+    
+    
+    
+
+    
+    
+    
+
+    
+
+  
+
+<div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/noticia/la-asociacion-de-academias-de-la-lengua-espanola-celebra-su-70o-aniversario-bajo-la">70 AÑOS DE ASALE</a></p>
+
+      <div data-nosnippet class="block-news__img img">
+      <a target="_self" title="Actos de celebración del 70 aniversario" href="/noticia/la-asociacion-de-academias-de-la-lengua-espanola-celebra-su-70o-aniversario-bajo-la">
+        <img class="b-lazy"
+             src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+             data-src="/sites/default/files/styles/tambien_interesa/public/2021-12/70%20anos%20asale.jpg?itok=kU8Y2JlT"
+             alt="Los reyes de España han presidido en el salón de actos de la RAE el solemne acto institucional conmemorativo del septuagésimo aniversario de la Asociación de Academias de la Lengua Española (ASALE). Foto: RAE. " />
+      </a>
+    </div>
+  
+      <span class="news__date">
+      
+    </span>
+  
+  <p class="block-news__title u-text-brandsecondary">
+    <a target="_self" title="Actos de celebración del 70 aniversario" href="/noticia/la-asociacion-de-academias-de-la-lengua-espanola-celebra-su-70o-aniversario-bajo-la">
+      Actos de celebración del 70 aniversario
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+
+  
+
+<div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/obras-academicas/clasicos-asale">Clásicos ASALE</a></p>
+
+      <div data-nosnippet class="block-news__img img">
+      <a target="_self" title="Conozca los títulos de toda la colección" href="/obras-academicas/clasicos-asale">
+        <img class="b-lazy"
+             src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+             data-src="/sites/default/files/styles/tambien_interesa/public/imagenes/articulos/Foto_La_Voz_de_Galicia_1_1.png?itok=nG30FJfh"
+             alt="Nuevos títulos de la colección Clásicos ASALE  " />
+      </a>
+    </div>
+  
+      <span class="news__date">
+      
+    </span>
+  
+  <p class="block-news__title u-text-brandsecondary">
+    <a target="_self" title="Conozca los títulos de toda la colección" href="/obras-academicas/clasicos-asale">
+      Conozca los títulos de toda la colección
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+
+        
+
+    
+    
+
+    
+</div>
+</div>
+
+      </div>
+
+
+      <div data-nosnippet class="col-xs-12 col-md-6 col-lg-8 u-border-left"
+           data-aos="fade-up"
+           data-aos-offset="150"
+           data-aos-delay="400"
+           data-aos-duration="800">
+          <div data-nosnippet class="views-element-container">
+<div data-nosnippet class="js-view-dom-id-b5df2b64bbf6d0641e267cd9ab9d13eb19064524d5085d5ec1cde593ffb30d5b vista">
+    
+    
+    
+
+    
+    
+    
+
+    
+<div data-nosnippet class="row">
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/lexicografia" hreflang="es">Lexicografía</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Cuarta convocatoria del Programa ASALE de becas de formación y colaboración destinado a las academias de la Asociación de Academias de la Lengua Española (ASALE) " href="/noticia/cuarta-convocatoria-del-programa-asale-de-becas-de-formacion-y-colaboracion-destinado-las">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/imagenes/articulos/centro_de_estudios_RAE_serrano.jpg?h=c9f93661&amp;itok=zfPMAJv-"
+               alt="Sede de la Escuela de Lexicografía (Serrano, 187-189) en Madrid (foto: RAE)">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2025-05-27T12:00:00Z">27 de Mayo de 2025</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Cuarta convocatoria del Programa ASALE de becas de formación y colaboración destinado a las academias de la Asociación de Academias de la Lengua Española (ASALE) " href="/noticia/cuarta-convocatoria-del-programa-asale-de-becas-de-formacion-y-colaboracion-destinado-las">
+      <span>Cuarta convocatoria del Programa ASALE de becas de formación y colaboración destinado a las academias de la Asociación de Academias de la Lengua Española (ASALE) </span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/academicos" hreflang="es">Académicos</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Carlos Martini, nuevo miembro de número de la Academia Paraguaya de la Lengua Española" href="/noticia/carlos-martini-nuevo-miembro-de-numero-de-la-academia-paraguaya-de-la-lengua-espanola">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/2021-11/Sede_APARLE.jpg?h=9e499333&amp;itok=BhYtrdjy"
+               alt="Sede de la Academia Paraguaya de la Lengua Española">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2025-01-13T12:00:00Z">13 de Enero de 2025</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Carlos Martini, nuevo miembro de número de la Academia Paraguaya de la Lengua Española" href="/noticia/carlos-martini-nuevo-miembro-de-numero-de-la-academia-paraguaya-de-la-lengua-espanola">
+      <span>Carlos Martini, nuevo miembro de número de la Academia Paraguaya de la Lengua Española</span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/obituarios" hreflang="es">Obituarios</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Fallece Tarsicio Herrera Zapién, miembro de la Academia Mexicana de la Lengua" href="/noticia/fallece-tarsicio-herrera-zapien-miembro-de-la-academia-mexicana-de-la-lengua">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/imagenes/academicos/Tarsicio_Herrera_Sapien_www.cultura.gob_.mx_.jpg?h=c9f93661&amp;itok=XE1zuFdY"
+               alt="Tarsicio Herrera Zapién, miembro de número de la Academia Mexicana de la Lengua. Foto: Secretaría de Cultura.">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2026-02-05T12:00:00Z">5 de Febrero de 2026</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Fallece Tarsicio Herrera Zapién, miembro de la Academia Mexicana de la Lengua" href="/noticia/fallece-tarsicio-herrera-zapien-miembro-de-la-academia-mexicana-de-la-lengua">
+      <span>Fallece Tarsicio Herrera Zapién, miembro de la Academia Mexicana de la Lengua</span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/academicos" hreflang="es">Académicos</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Félix Julio Alfonso López ingresa en la Academia Cubana de la Lengua" href="/noticia/felix-julio-alfonso-lopez-ingresa-en-la-academia-cubana-de-la-lengua">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/2026-02/F%C3%A9lix%20Julio%20Alfonso%20L%C3%B3pez_0.jpg?h=8b436e18&amp;itok=6lYXMiAr"
+               alt="Félix Julio Alfonso López">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2026-02-04T12:00:00Z">4 de Febrero de 2026</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Félix Julio Alfonso López ingresa en la Academia Cubana de la Lengua" href="/noticia/felix-julio-alfonso-lopez-ingresa-en-la-academia-cubana-de-la-lengua">
+      <span>Félix Julio Alfonso López ingresa en la Academia Cubana de la Lengua</span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+  </div>
+
+        
+
+    
+    
+
+    
+</div>
+</div>
+
+      </div>
+
+
+    </div>
+  </div>
+</section>
+
+            <section class="section o-section--medium">
+
+  <div data-nosnippet class="container">
+    <div data-nosnippet class="u-text-center">
+
+      <div data-nosnippet class="btn btn-up" data-aos="fade-up" data-aos-offset="50" data-aos-delay="200" data-aos-duration="1000">
+        <a href="#main" class="ancla">
+          <svg class="icon icon--small icon-black">
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-up"></use>
+          </svg>
+          <p class="btn__text">Arriba</p>
+        </a>
+      </div>
+
+    </div>
+  </div>
+
+</section>
+
+    </div>
+  </div>
+
+  
+  <footer id="footer" class="footer">
+  <div data-nosnippet class="container">
+    <div data-nosnippet class="pre-footer">
+
+      <p class="footer-privacidad">
+        REAL ACADEMIA ESPAÑOLA. Finalidades: Recopilación de información lingüística para la investigación, desarrollo, proyección y buen uso de la lengua española en el ámbito de la IA (proyecto LEIA). Derechos: tiene derecho a acceder, rectificar y suprimir sus datos, así como a otros derechos como se explica en la información adicional y detallada que se puede consultar en nuestra 
+        <span class="privacidad-link privacidad-link--inverse"><a href="/politica-de-privacidad-y-proteccion-de-los-datos-personales" target="_blank">política de privacidad</a>.</span>
+      </p>
+
+    </div>
+
+    <div data-nosnippet class="sub-footer">
+      <div data-nosnippet class="sub-footer__social">
+        <a title="Síganos en X" href="https://x.com/RAEinforma" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en X</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#twitter"></use>
+    </svg>
+</a>
+<a title="Síganos en Facebook"  href="https://www.facebook.com/RAE/" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en Facebook</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#facebook"></use>
+    </svg>
+</a>
+<a title="Visite nuestro Instagram" href="https://www.instagram.com/laraeinforma/" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Visite nuestro Instagram</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#instagram"></use>
+    </svg>
+</a>
+<a title="Síganos en TikTok" href="https://www.tiktok.com/@rae.informa" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en TikTok</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#tiktok"></use>
+    </svg>
+</a>
+<a title="Visite nuestras galerías" href="https://www.flickr.com/photos/raeinforma" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Visite nuestras galerías</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#flicker"></use>
+    </svg>
+</a>
+<a title="Síganos en Youtube" href="https://www.youtube.com/user/RAEInforma" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en Youtube</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#youtube"></use>
+    </svg>
+</a>
+
+<a title="Escuche nuestras listas de música" href="https://open.spotify.com/user/u0gt78txho8qqa5m843kkvxy2" rel="noopener" target="_blank">
+  <svg class="icon icon--medium">
+    <title>Escuche nuestras listas de música</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#spoty"></use>
+  </svg>
+</a>
+
+<a title="Síganos en Souncloud" href="https://soundcloud.com/real-academia-espanola" rel="noopener" target="_blank">
+  <svg class="icon icon--medium">
+    <title>Síganos en Soundcloud</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#soundcloud"></use>
+  </svg>
+</a>
+
+<a title="Contacte con nosotros" href="/contacto-rae">
+  <svg class="icon icon--medium">
+    <title>Contacte con nosotros</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#email"></use>
+  </svg>
+</a>
+
+      </div>
+
+      <div data-nosnippet class="sub-footer__link">
+        <a title="Visitar Fundación pro-RAE" href="/fundacion">Fundación pro-Rae</a>
+        <a title="Visitar web ASALE" href="https://www.asale.org/" rel="noopener" target="_blank">Asale</a>
+      </div>
+
+
+      <p class="footer__text">
+        Felipe IV, 5 - 28014 Madrid - Teléfono:
+        <a title="Teléfono contacto" href="tel:34914201478">+34 91 420 14 78</a>
+        <span class="ml-1 d-inline-block">
+          © Real Academia Española, 2019
+        </span>
+      </p>
+
+      
+
+<nav role="navigation" aria-labelledby="block-piedepagina" id="block-piedepagina" class="block block-menu navigation block-system-menublock menu--footer">
+      
+        
+
+                        <ul class="footer-list">
+                            <li class="footer-list__item">
+                <a href="https://rae.whistlelink.com" target="_blank">Canal del informante</a>
+                            </li>
+                </ul>
+    
+
+
+  </nav>
+
+    </div>
+
+  </div>
+</footer>
+
+<div data-nosnippet class="search-full-container">
+  <span class="menu-buttom__close">
+  <svg class="icon icon--xsmall icon-black">
+    <title>cerrar</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#close"></use>
+  </svg>
+</span>
+  <div data-nosnippet class="container">
+
+    <div data-nosnippet class="header__logo">
+      <div data-nosnippet class="img">
+        <a href="/" title="Inicio - Real Academia Española" rel="home" class="site-logo">
+          <svg class="icon icon-logo">
+            <title>Logo RAE</title>
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#logo-rae"></use>
+          </svg>
+        </a>
+      </div>
+    </div>
+    <div data-nosnippet class="row justify-content-center">
+      <div data-nosnippet class="col-12 col-md-8">
+        <h2 class="search__title">Buscador general de la RAE</h2>
+
+        <form class="search-block-form" data-drupal-selector="search-block-form" action="/search/node" method="get" id="search-block-form" accept-charset="UTF-8">
+  <div data-nosnippet class="js-form-item form-item js-form-type-search form-type-search js-form-item-keys form-item-keys form-no-label">
+      <label for="edit-keys" class="visually-hidden">Search</label>
+        <input title="Escriba lo que quiere buscar." placeholder="Buscar en la web" data-drupal-selector="edit-keys" type="search" id="edit-keys" name="keys" value="" size="15" maxlength="128" class="form-search" />
+
+        </div>
+<div data-nosnippet data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions"><input alt="Buscar en la web" data-drupal-selector="edit-submit" type="image" id="edit-submit" name="op" src="/themes/custom/front/src/assets/images/lupa.svg" class="image-button js-form-submit form-submit" />
+</div>
+
+</form>
+
+      </div>
+    </div>
+  </div>
+</div>
+
+<div data-nosnippet class="dle-full-container">
+  <span class="menu-buttom__close">
+  <svg class="icon icon--xsmall icon-black">
+    <title>cerrar</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#close"></use>
+  </svg>
+</span>
+  <div data-nosnippet class="contenedor-full">
+
+    <div data-nosnippet class="container">
+      <div data-nosnippet class="row justify-content-between">
+
+        <div data-nosnippet class="col-xs-12 col-lg-7">
+          <div data-nosnippet class="diccionarios-container">
+            <h2 class="diccionarios-container__title">Diccionarios</h2>
+            <form class="diccionarios-form" data-drupal-selector="diccionarios-form" action="/" method="post" id="diccionarios-form" accept-charset="UTF-8">
+  <div data-nosnippet id="edit-diccionario"><div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dle" type="radio" id="edit-diccionario-dle" name="diccionario" value="dle" checked="checked" class="form-radio" />
+
+        <label for="edit-diccionario-dle" class="option">Diccionario de la lengua española</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dpd" type="radio" id="edit-diccionario-dpd" name="diccionario" value="dpd" class="form-radio" />
+
+        <label for="edit-diccionario-dpd" class="option">Diccionario panhispánico de dudas</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dpej" type="radio" id="edit-diccionario-dpej" name="diccionario" value="dpej" class="form-radio" />
+
+        <label for="edit-diccionario-dpej" class="option">Diccionario panhispánico del español jurídico</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dhle" type="radio" id="edit-diccionario-dhle" name="diccionario" value="dhle" class="form-radio" />
+
+        <label for="edit-diccionario-dhle" class="option">Diccionario histórico de la lengua española</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-damer" type="radio" id="edit-diccionario-damer" name="diccionario" value="damer" class="form-radio" />
+
+        <label for="edit-diccionario-damer" class="option">Diccionario de americanismos</label>
+      </div>
+</div>
+<fieldset data-drupal-selector="edit-caja" id="edit-caja" class="form-item js-form-wrapper form-wrapper">
+      <legend>
+    <span class="fieldset-legend"></span>
+  </legend>
+  <div data-nosnippet class="fieldset-wrapper">
+            <div data-nosnippet class="js-form-item form-item js-form-type-textfield form-type-textfield js-form-item-termino form-item-termino form-no-label">
+        <input aria-label="Término" data-drupal-selector="edit-termino" type="text" id="edit-termino" name="termino" value="" size="60" maxlength="128" placeholder="Escriba el término" class="form-text required" required="required" aria-required="true" />
+
+        </div>
+<input class="icon--small image-button js-form-submit form-submit" alt="Escriba el término" data-drupal-selector="edit-submit" type="image" id="edit-submit--2" name="op" src="/themes/custom/front/src/assets/images/lupa.svg" />
+
+          </div>
+</fieldset>
+<div data-nosnippet class="logo"><div data-nosnippet data-drupal-selector="edit-lacaixa-modal" data-drupal-states="{&quot;visible&quot;:[{&quot;:input[name=\u0022diccionario\u0022]&quot;:{&quot;value&quot;:&quot;dle&quot;}}]}" id="edit-lacaixa-modal" class="js-form-wrapper form-wrapper"><a title="Fundación “la Caixa”" rel="noopener" target="_blank" href="https://fundacionlacaixa.org/es/home"><img src="/themes/custom/front/src/assets/svg/logo-fundacion-caixa.svg" alt="Logo Obra social “la Caixa”"></a></div>
+</div><input autocomplete="off" data-drupal-selector="form-xia40oqp-xumj65oafjg5thtpkciat38yywr-l468i4" type="hidden" name="form_build_id" value="form-XIA40Oqp-xUMJ65oafjg5thtPkCIat38YyWR-l468I4" />
+<input data-drupal-selector="edit-diccionarios-form" type="hidden" name="form_id" value="diccionarios_form" />
+<div data-nosnippet data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions--3"></div>
+
+</form>
+
+          </div>
+        </div>
+        <div data-nosnippet class="col-xs-12 col-lg-4">
+          <div data-nosnippet class="dudas-container">
+            <h2 class="dudas-container__title">Dudas rápidas</h2>
+            <form class="dudas-form-modal" data-drupal-selector="dudas-form-modal" action="/" method="post" id="dudas-form-modal" accept-charset="UTF-8">
+  <fieldset data-drupal-selector="edit-caja-dudas-modal" id="edit-caja-dudas-modal" class="form-item js-form-wrapper form-wrapper">
+      <legend>
+    <span class="fieldset-legend"></span>
+  </legend>
+  <div data-nosnippet class="fieldset-wrapper">
+            <div data-nosnippet class="js-form-item form-item js-form-type-textfield form-type-textfield js-form-item-duda-modal form-item-duda-modal form-no-label">
+        <input aria-label="Término" data-drupal-selector="edit-duda-modal" type="text" id="edit-duda-modal" name="duda_modal" value="" size="60" maxlength="128" placeholder="Escriba las palabras clave" class="form-text required" required="required" aria-required="true" />
+
+        </div>
+<input class="icon--small image-button js-form-submit form-submit" alt="Buscar duda" data-drupal-selector="edit-submit-modal" type="image" id="edit-submit-modal" name="op" src="/themes/custom/front/src/assets/images/lupa.svg" />
+
+          </div>
+</fieldset>
+<input autocomplete="off" data-drupal-selector="form-cvfp2zsxkvagunug3dkccupvudyupyammxp4ka-jrzq" type="hidden" name="form_build_id" value="form-cvFP2zsxkVagunUg3dKcCupVUDYUPYAMMXp4kA-JRZQ" />
+<input data-drupal-selector="edit-dudas-form-modal" type="hidden" name="form_id" value="dudas_form_modal" />
+<div data-nosnippet data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions--5"></div>
+
+</form>
+
+          </div>
+        </div>
+      </div>
+
+      <div data-nosnippet class="recursos-container">
+        <h2 class="title__medium text-center mb-7">
+          Otros Recursos
+          <svg class="icon icon--xsmall icon-black">
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#plus"></use>
+          </svg>
+          <svg class="icon icon--xsmall icon-black hidden">
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#menos"></use>
+          </svg>
+        </h2>
+        <div data-nosnippet class="lista-recursos-container">
+          
+
+
+    
+          <ul class="lista-recursos" >
+    
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Diccionarios</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://dle.rae.es/">Diccionario de la lengua española</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/dpd/">Diccionario panhispánico de dudas</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://dpej.rae.es/">Diccionario panhispánico del español jurídico</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="/dhle">Diccionario histórico de la lengua española</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.asale.org/damer/">Diccionario de americanismos</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/diccionario-estudiante/" title="Diccionario del estudiante">Diccionario del estudiante</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/tdhle/" title="Tesoro de diccionarios históricos de la lengua">Tesoro de diccionarios históricos de la lengua</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/DA.html">Diccionario de autoridades</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://apps.rae.es/ntlle/SrvltGUISalirNtlle">Nuevo tesoro lexicográfico</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/ntllet/SrvltGUILoginNtlletPub">Mapa de diccionarios</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/DH1936.html">Diccionario histórico (1933-1936)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/DH.html">Diccionario histórico (1960-1996)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/drae2001/">Diccionario de la lengua española (2001)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/desen/">Diccionario esencial (2006)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/formulario-de-la-unidad-interactiva-del-diccionario" title="Envíe las propuestas y sugerencias externas relacionadas con el «Diccionario de la lengua española»">Unidad Interactiva del Diccionario (UNIDRAE)</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Banco de datos</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/corpes/">CORPES XXI</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/CNDHE/">CDH</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://corpus.rae.es/creanet.html">CREA</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/crea-anotado/" title="CREA anotado">CREA anotado</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://corpus.rae.es/cordenet.html">CORDE</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/fichero.html">Fichero general</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.asale.org/corpus-asale/">Corpus ASALE</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Gramática</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://aplica.rae.es/grweb/cgi-bin/buscar.cgi">Nueva gramática de la lengua española</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/gtg/">Glosario de términos gramaticales</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/sites/default/files/Gramatica_RAE_1771_reducida.pdf">Primera gramática</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/gram%C3%A1tica-b%C3%A1sica/" title="Nueva gramática básica de la lengua española">Nueva gramática básica de la lengua española</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Ortografía</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://aplica.rae.es/orweb/cgi-bin/buscar.cgi">Ortografía 2010</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="/sites/default/files/Ortografia_RAE_1741_reducida.pdf">Primera ortografía</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/ortograf%C3%ADa-b%C3%A1sica/" title="Ortografía básica de la lengua española">Ortografía básica de la lengua española</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Biblioteca</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca/biblioteca-academica">Biblioteca académica</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca/legado-antonio-rodriguez-monino-y-maria-brey">Legado Rodríguez-Moñino</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca/legado-damaso-alonso">Legado Dámaso Alonso</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca-digital" title="Biblioteca Digital">Biblioteca Digital</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Archivo</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://archivo.rae.es/">Fondo institucional</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://archivo.rae.es/index.php/coleccion-de-autografos-de-pedro-antonio-de-alarcon">Colección P. A. de Alarcón</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://archivo.rae.es/zorrilla/">Zorrilla</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/manuscritos-para-la-segunda-edicion-del-diccionario-de-autoridades">2.ª edición del «Diccionario de autoridades»</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://archivo.rae.es/fichero-de-hilo">Fichero de hilo</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Boletines</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://revistas.rae.es/bilrae/">BILRAE</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://revistas.rae.es/brae">BRAE</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span title="Recursos académicos de apoyo para el lenguaje claro">Lenguaje claro</span>
+          </div>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Enclave</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://enclavedeciencia.rae.es/inicio">Enclave de Ciencia</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Enlaces externos</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://asines.org/">Atlas sintáctico del español</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/dhecan.html">Diccionario Histórico del Español de Canarias</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/CORLEXIN.html">Corpus Léxico de Inventarios</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://lla.unileon.es/" title="Léxico leonés actual">Léxico leonés actual</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+    
+  </ul>
+  
+
+
+        </div>
+      </div>
+
+
+    </div>
+
+  </div>
+</div>
+
+</div>
+
+  </div>
+
+      
+
+    </div>
+
+    
+
+
+  <script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script src="/sites/default/files/js/js_7hSOT9HVKxMvGlrclR4TDcqOUtAR-0e88Vkq_P_PROE.js"></script>\n<script src="/damer/js/20210406.js"></script>
+<!--[if IE]>
+<style>
+#deletex{ display:none;}
+</style>
+<![endif]-->
+</body>
+<script>
+window.cat='EXTERNO';window.acc='www.asale.org/damer/living';window.eti='https://www.asale.org/damer/grampa';
+</script>
+</html>

--- a/tests/cogs/damer_sample_htmls/yanchama.html
+++ b/tests/cogs/damer_sample_htmls/yanchama.html
@@ -1,0 +1,1358 @@
+<!DOCTYPE html>
+<html lang="es">
+<head><noscript><style>form.antibot * :not(.antibot-message) { display: none !important; }</style></noscript>
+<link rel="preload" href="/sites/default/files/css/css_2toHNXfbnPicu5GM0gX9NZ5orfKOc_JkPXeCbZqaWws.css" as="style">
+<link rel="preload" href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&amp;display=swap" as="style">
+<link rel="preload" href="https://fonts.googleapis.com/css2?family=Merriweather:wght@700&amp;display=swap" as="style">
+<link rel="preload" href="/sites/default/files/css/css_MKU0IOMhjZnRGgSeMxmlSpwNVcEMZOFPTb3EZkC-BVI.css" as="style">
+<link rel="preload" href="/sites/default/files/js/js_7hSOT9HVKxMvGlrclR4TDcqOUtAR-0e88Vkq_P_PROE.js" as="script">
+<link rel="preload" href="/damer/css/20201019.css" as="style">
+<link rel="preload" href="/damer/js/20210406.js" as="script">
+<link rel="preload" href="/themes/custom/front/assets/fonts/lato/lato-bold-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/lato/lato-regular-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/merriweather/merriweather-black-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/merriweather/merriweather-light-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="/themes/custom/front/assets/fonts/merriweather/merriweather-regular-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="canonical" href="https://www.asale.org/damer/yanchama"/>
+<title>yanchama | Diccionario de americanismos | ASALE</title>
+<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="I. 1. Co. Lienzo que se obtiene de la corteza de ciertos árboles y que los indígenas del Amazonas pintan con colorantes vegetales. 2. Ec , Pe."/>
+<meta name="keywords" content="yanchama, definición de yanchama, significado de yanchama, ASALE, RAE"/>
+<meta name="author" content="ASALE"/>
+<meta name="robots" content="index,follow"/>
+<meta name="rating" content="safe for kids"/>
+<meta name="rights" content="Asociación de Academias de la Lengua Española © Todos los derechos reservados"/>
+<meta name="author" content="ASALE">
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:site" content="\@ASALEinforma"/>
+<meta name="twitter:url" content="https://www.asale.org/damer/yanchama"/>
+<meta name="twitter:title" content="yanchama | Diccionario de americanismos"/>
+<meta name="twitter:description" content="I. 1. Co. Lienzo que se obtiene de la corteza de ciertos árboles y que los indígenas del Amazonas pintan con colorantes vegetales. 2. Ec , Pe."/>
+<meta name="twitter:image" content="/damer/img/logo-asale.png"/>
+<meta name="twitter:image:alt" content="«Diccionario de americanismos»"/>
+<meta property="article:author" content="https://es-es.facebook.com/asale"/>
+<meta property="og:title" content="yanchama | Diccionario de americanismos"/>
+<meta property="og:type" content="website"/>
+<meta property="og:site_name" content="«Diccionario de americanismos»"/>
+<meta property="og:url" content="https://www.asale.org/damer/yanchama"/>
+<meta property="og:description" content="I. 1. Co. Lienzo que se obtiene de la corteza de ciertos árboles y que los indígenas del Amazonas pintan con colorantes vegetales. 2. Ec , Pe."/>
+<meta property="og:locale" content="es"/>
+<meta property="og:image" content="/damer/img/logo-asale.png"/>
+<meta property="og:image:type" content="image/png"/>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<link rel="shortcut icon" href="/themes/custom/front/favicon.ico" />
+<link rel="mask-icon" href="/themes/custom/front/src/assets/images/favicons/safari-pinned-tab.svg" />
+<link rel="icon" sizes="16x16" href="/themes/custom/front/src/assets/images/favicons/favicon-16x16.png" />
+<link rel="icon" sizes="32x32" href="/themes/custom/front/src/assets/images/favicons/favicon-32x32.png" />
+<link rel="apple-touch-icon" sizes="180x180" href="/themes/custom/front/src/assets/images/favicons/apple-touch-icon.png" />
+<link rel="apple-touch-icon-precomposed" sizes="180x180" href="/themes/custom/front/src/assets/images/favicons/apple-touch-icon.png" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=2, minimum-scale=1, user-scalable=yes" />
+<!--[if lt IE 9]><script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+<script type="application/ld+json">
+[{"@context": "http://schema.org/"},{"@type": ["DefinedTermSet","Book"],"@id": "https://www.asale.org/damer","name": "Diccionario de americanismos RAE - ASALE","image": "https://www.asale.org/damer/img/logo-asale.png","description": "Versión electrónica del «Diccionario de americanismos»."},{"@type": "DefinedTerm","@id": "https://www.asale.org/damer/yanchama","name": "yanchama","description": "I. 1. Co. Lienzo que se obtiene de la corteza de ciertos árboles y que los indígenas del Amazonas pintan con colorantes vegetales. 2. Ec , Pe.","inDefinedTermSet": "https://www.asale.org/damer"}]
+</script><link rel="stylesheet" media="all" href="/sites/default/files/css/css_2toHNXfbnPicu5GM0gX9NZ5orfKOc_JkPXeCbZqaWws.css"/>
+<link rel="stylesheet" media="all" href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&amp;display=swap"/>
+<link rel="stylesheet" media="all" href="https://fonts.googleapis.com/css2?family=Merriweather:wght@700&amp;display=swap"/>
+<link rel="stylesheet" media="all" href="/sites/default/files/css/css_MKU0IOMhjZnRGgSeMxmlSpwNVcEMZOFPTb3EZkC-BVI.css"/>
+<script>window.a2a_config=window.a2a_config||{};a2a_config.callbacks=[];a2a_config.overlays=[];a2a_config.templates={};a2a_config.static_server= "http://www.asale.org/sites/default/files/addtoany/menu/oafg07ee";a2a_config.icon_color = "transparent,#000";</script>
+
+<link rel="stylesheet" media="all" href="/damer/css/20201019.css"/>
+</head>
+<body class="path--node body-sidebars-none alias--noticia-primera-reunion-plenaria-virtual-de-directores-y-presidentes-de-las-academias-de-la-lengua nodetype--noticia logged-out" data-aos-easing="ease" data-aos-duration="400" data-aos-delay="0">
+<div role="main">
+<div class="dialog-off-canvas-main-canvas" data-off-canvas-main-canvas="">
+<div class="page-standard" id="pg__c">
+
+<header id="header" class="header">
+
+  <div class="header__logo">
+    <div class="img">
+                <a href="/" title="Inicio - ASALE" rel="home" class="site-logo">
+            <img src="/themes/custom/asale/assets/images/logo-asale.png" alt="Logo ASALE"/>
+          </a>
+          </div>
+  </div>
+
+  <div class="header-menu-search">
+
+    <nav class="header-menu">
+
+      <div class="main-menu-container">
+        <span class="menu-buttom__close">
+  <svg class="icon icon--xsmall icon-black">
+    <title>cerrar</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#close"></use>
+  </svg>
+</span>
+        
+
+<nav role="navigation" aria-labelledby="block-navegacionprincipalasale" id="block-navegacionprincipalasale" class="block block-menu navigation block-system-menublock menu--main-asale">
+      
+        
+
+
+              <ul class="menu-list main">
+              <li class="menu-list__item" >
+
+                  <div class="parent-item">
+            <a href="/la-asociacion" data-drupal-link-system-path="node/29051">La Asociación</a>
+            <span class="menu-collapse">
+              <svg class="icon icon--xsmall icon-black">
+                <title>Abrir submenu</title>
+                <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-bottom"></use>
+              </svg>
+            </span>
+          </div>
+        
+
+                                <ul>
+              <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/bienvenida" data-drupal-link-system-path="node/31480">Bienvenida</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/presentacion" data-drupal-link-system-path="node/31494">Presentación</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/comision-permanente" data-drupal-link-system-path="node/29478">Comisión Permanente</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/politica-panhispanica" data-drupal-link-system-path="node/31648">Política panhispánica</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/actividad-institucional" data-drupal-link-system-path="node/31515">Actividad institucional</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/biblioteca-de-la-asale" data-drupal-link-system-path="node/31634">Biblioteca de la ASALE</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/la-asociacion/conmemoraciones" data-drupal-link-system-path="node/31641">Conmemoraciones</a>
+        
+
+              </li>
+      </ul>
+    
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/academias" data-drupal-link-system-path="academias">Academias</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <div class="parent-item">
+            <a href="/obras" data-drupal-link-system-path="node/29030">Obras</a>
+            <span class="menu-collapse">
+              <svg class="icon icon--xsmall icon-black">
+                <title>Abrir submenu</title>
+                <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-bottom"></use>
+              </svg>
+            </span>
+          </div>
+        
+
+                                <ul>
+              <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/diccionarios" data-drupal-link-system-path="taxonomy/term/100">Diccionarios</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/gramatica" data-drupal-link-system-path="taxonomy/term/101">Gramática</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/ortografia" data-drupal-link-system-path="taxonomy/term/102">Ortografía</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/ediciones-conmemorativas" data-drupal-link-system-path="taxonomy/term/103">Ediciones conmemorativas</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/clasicos-asale" data-drupal-link-system-path="taxonomy/term/337">Clásicos ASALE</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/obras-academicas/otras-obras" data-drupal-link-system-path="taxonomy/term/330">Otras obras</a>
+        
+
+              </li>
+      </ul>
+    
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/corpus" data-drupal-link-system-path="node/29037">Corpus</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <div class="parent-item">
+            <a href="/escuela-de-lexicografia" data-drupal-link-system-path="node/29044">Escuela de Lexicografía</a>
+            <span class="menu-collapse">
+              <svg class="icon icon--xsmall icon-black">
+                <title>Abrir submenu</title>
+                <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-bottom"></use>
+              </svg>
+            </span>
+          </div>
+        
+
+                                <ul>
+              <li class="menu-list__item" >
+
+                  <a href="/escuela-de-lexicografia/la-elh" data-drupal-link-system-path="node/32131">La ELH</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/escuela-de-lexicografia/master-de-lexicografia-hispanica-y-correccion-linguistica" data-drupal-link-system-path="node/88530">Máster</a>
+        
+
+              </li>
+      </ul>
+    
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/publicaciones" data-drupal-link-system-path="node/28988">Publicaciones</a>
+        
+
+              </li>
+          <li class="menu-list__item" >
+
+                  <a href="/noticias" data-drupal-link-system-path="noticias">Noticias</a>
+        
+
+              </li>
+      </ul>
+    
+
+
+  </nav>
+      </div>
+
+      <ul class="search-block">
+        <li class="menu-list__item link-dle">
+          <svg class="icon icon--tiny icon-white">
+            <title>Recursos</title>
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#diccionarios"></use>
+          </svg>
+          <span class="menu-list__text">Recursos</span>
+        </li>
+        <li class="menu-list__item link-search">
+          <svg class="icon icon--xsmall icon-white">
+            <title>Buscador</title>
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#lupa"></use>
+          </svg>
+        </li>
+        <li class="menu-list__item link-menu">
+          <svg class="icon icon--small icon-white">
+            <title>Menu</title>
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#menu"></use>
+          </svg>
+        </li>
+      </ul>
+
+    </nav>
+  </div>
+</header>
+<div class="container">
+<div class="row">
+<div class="col-xs-12 col-md-8" style="border-right:1px solid #ccc">  
+<div style="margin: 20px 0 10px 0;font-size:2em"><a href="/damer/">Diccionario de americanismos</a></div>
+<div class="form-box-wrapper">
+<div class="form-box"><form action="#" method="post" class="form form-damer" id="formulario"><input size="30" style="border:1px solid #ccc" class="custom-search-box" name="w" id="wq" type="text" value="" placeholder="Escriba aquí la palabra" autocomplete="off" autocapitalize="off"/><input style="margin-left:5px" alt="Buscar" type="image" class="icon icon--xsmall icon-grey" src="/themes/custom/front/src/assets/images/lupa.svg" name="submit"></form></div>
+<div class="addtext"><a style="" href="javascript:addText('á','damer');">á</a><a style="" href="javascript:addText('é','damer');">é</a><a style="" href="javascript:addText('í','damer');">í</a><a style="" href="javascript:addText('ó','damer');">ó</a><a style="" href="javascript:addText('ú','damer');">ú</a><a style="" href="javascript:addText('ü','damer');">ü</a><a style="" href="javascript:addText('ñ','damer');">ñ</a></div>
+</div>
+
+<div class="bloque-txt" id="resultados">
+<entry xmlns="http://www.w3.org/1999/xhtml" header="yanchama" key="yanchama" id="x7F9IwDyux0AB6TSyuw">
+<table class="da4"><tr><td colspan="5" class="da2"><span class="da8">yanchama.</span></td></tr><tr><td> </td><td class="da7"><span class="da3">I.</span></td><td class="da7"><span class="da3">1.</span></td><td colspan="2" class="da6">f. <i><span class="da5">Co.</span></i><span class="da5"> Lienzo que se obtiene de la corteza de ciertos &#xE1;rboles y que los ind&#xED;genas del Amazonas pintan con colorantes vegetales.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">2.</span></td><td valign="top" colspan="2"><i><span class="da5">Ec</span></i><span class="da5">, </span><i><span class="da5">Pe.</span></i><span class="da5"> &#xC1;rbol de hasta 30 m de altura, de tronco recto con la corteza exterior gris claro, copa redonda o irregular, poco densa, hojas simples, alternas, de borde enteros, flores amarillas, frutos globosos, con el extremo apical en forma de estrella, de color verde, </span><span class="da0">torn&#xE1;ndose amarillos al madurar</span><span class="da5">. (Moraceae; </span><i><span class="da5">Poulsenia armata</span></i><span class="da5">). (</span><a href='llanchama'>llanchama</a><span class="da5">).</span><span class="da5"> &#x25C6; </span><span class="da3">cucu&#xE1;</span><span class="da5">; </span><span class="da3">&#xF1;umi</span><span class="da5">.</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">3.</span></td><td valign="top" colspan="2"><i><span class="da5">Pe.</span></i><span class="da5"> Material o fibra sacados de la corteza de la yanchama. (</span><a href='llanchama'>llanchama</a><span class="da5">).</span></td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">4.</span></td><td valign="top" colspan="2"><i><span class="da5">Pe.</span></i><span class="da5"> Madera de la yanchama. (</span><a href='llanchama'>llanchama</a><span class="da5">).</span></td></tr><tr><td> </td><td class="da7"><span class="da3">&#x25A0;</span></td><td> </td><td> </td><td> </td></tr><tr><td> </td><td> </td><td class="da7"><span class="da3">a. &#x1C1; </span></td><td colspan="2"><span class="da0">~</span><span class="da3"> oj&#xE9;.</span><span class="da5"> f. </span><i><span class="da5">Co.</span></i><span class="da5"> &#xC1;rbol de hasta 30 m de altura, de corteza exterior blanca o gris&#xE1;cea, hojas simples y alternas, de bordes enteros y frutos globosos; </span><span class="da0">de su corteza se obtiene la tela para hacer la yanchama</span><span class="da5">. (Moraceae; </span><i><span class="da5">Ficus glabrata</span></i><span class="da5">).</span><span class="da5"> &#x25C6; </span><span class="da3">oj&#xE9;</span><span class="da5">.</span></td></tr></table>
+</entry>
+<p class="o"><center><i><span class="d7">Diccionario de americanismos © 2010<br/>Asociación de Academias de la Lengua Española © Todos los derechos reservados</span></i></center></p><div class="compartir"><a title="Compartir en Facebook" class="resp-sharing-button__link" href="https://facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fyanchama" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--facebook resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M18.77 7.46H14.5v-1.9c0-.9.6-1.1 1-1.1h3V.5h-4.33C10.24.5 9.5 3.44 9.5 5.32v2.15h-3v4h3v12h5v-12h3.85l.42-4z"/></svg></div></div></a>
+<a title="Compartir en Twitter" class="resp-sharing-button__link" href="https://twitter.com/intent/tweet/?text=yanchama - Diccionario de americanismos&url=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fyanchama" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--twitter resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M23.44 4.83c-.8.37-1.5.38-2.22.02.93-.56.98-.96 1.32-2.02-.88.52-1.86.9-2.9 1.1-.82-.88-2-1.43-3.3-1.43-2.5 0-4.55 2.04-4.55 4.54 0 .36.03.7.1 1.04-3.77-.2-7.12-2-9.36-4.75-.4.67-.6 1.45-.6 2.3 0 1.56.8 2.95 2 3.77-.74-.03-1.44-.23-2.05-.57v.06c0 2.2 1.56 4.03 3.64 4.44-.67.2-1.37.2-2.06.08.58 1.8 2.26 3.12 4.25 3.16C5.78 18.1 3.37 18.74 1 18.46c2 1.3 4.4 2.04 6.97 2.04 8.35 0 12.92-6.92 12.92-12.93 0-.2 0-.4-.02-.6.9-.63 1.96-1.22 2.56-2.14z"/></svg></div></div></a>
+<a title="Compartir por correo electrónico" class="resp-sharing-button__link" href="/cdn-cgi/l/email-protection#99a6eaecfbf3fcfaeda4e0f8f7faf1f8f4f8b9b4b9ddf0fafaf0f6f7f8ebf0f6b9fdfcb9f8f4fcebf0faf8f7f0eaf4f6eabffbf6fde0a4f1edede9eaa3b6b6eeeeeeb7f8eaf8f5fcb7f6ebfeb6fdf8f4fcebb6e0f8f7faf1f8f4f8bca9d8bca9d8d0b7b9a8b7b9daf6b7b9d5f0fcf7e3f6b9e8ecfcb9eafcb9f6fbedf0fcf7fcb9fdfcb9f5f8b9faf6ebedfce3f8b9fdfcb9faf0fcebedf6eab95a38ebfbf6f5fceab9e0b9e8ecfcb9f5f6eab9f0f7fd5a34fefcf7f8eab9fdfcf5b9d8f4f8e3f6f7f8eab9e9f0f7edf8f7b9faf6f7b9faf6f5f6ebf8f7edfceab9effcfefcedf8f5fceab7b9abb7b9dcfab9b5b9c9fcb7" target="_self" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--email resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M22 4H2C.9 4 0 4.9 0 6v12c0 1.1.9 2 2 2h20c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zM7.25 14.43l-3.5 2c-.08.05-.17.07-.25.07-.17 0-.34-.1-.43-.25-.14-.24-.06-.55.18-.68l3.5-2c.24-.14.55-.06.68.18.14.24.06.55-.18.68zm4.75.07c-.1 0-.2-.03-.27-.08l-8.5-5.5c-.23-.15-.3-.46-.15-.7.15-.22.46-.3.7-.14L12 13.4l8.23-5.32c.23-.15.54-.08.7.15.14.23.07.54-.16.7l-8.5 5.5c-.08.04-.17.07-.27.07zm8.93 1.75c-.1.16-.26.25-.43.25-.08 0-.17-.02-.25-.07l-3.5-2c-.24-.13-.32-.44-.18-.68s.44-.32.68-.18l3.5 2c.24.13.32.44.18.68z"/></svg></div></div></a>
+<a title="Compartir en WhatsApp" class="resp-sharing-button__link" href="whatsapp://send?text=yanchama - Diccionario de americanismos%20https%3A%2F%2Fwww.asale.org%2Fdamer%2Fyanchama" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--whatsapp resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20.1 3.9C17.9 1.7 15 .5 12 .5 5.8.5.7 5.6.7 11.9c0 2 .5 3.9 1.5 5.6L.6 23.4l6-1.6c1.6.9 3.5 1.3 5.4 1.3 6.3 0 11.4-5.1 11.4-11.4-.1-2.8-1.2-5.7-3.3-7.8zM12 21.4c-1.7 0-3.3-.5-4.8-1.3l-.4-.2-3.5 1 1-3.4L4 17c-1-1.5-1.4-3.2-1.4-5.1 0-5.2 4.2-9.4 9.4-9.4 2.5 0 4.9 1 6.7 2.8 1.8 1.8 2.8 4.2 2.8 6.7-.1 5.2-4.3 9.4-9.5 9.4zm5.1-7.1c-.3-.1-1.7-.9-1.9-1-.3-.1-.5-.1-.7.1-.2.3-.8 1-.9 1.1-.2.2-.3.2-.6.1s-1.2-.5-2.3-1.4c-.9-.8-1.4-1.7-1.6-2-.2-.3 0-.5.1-.6s.3-.3.4-.5c.2-.1.3-.3.4-.5.1-.2 0-.4 0-.5C10 9 9.3 7.6 9 7c-.1-.4-.4-.3-.5-.3h-.6s-.4.1-.7.3c-.3.3-1 1-1 2.4s1 2.8 1.1 3c.1.2 2 3.1 4.9 4.3.7.3 1.2.5 1.6.6.7.2 1.3.2 1.8.1.6-.1 1.7-.7 1.9-1.3.2-.7.2-1.2.2-1.3-.1-.3-.3-.4-.6-.5z"/></svg></div></div></a>
+<a title="Compartir en Telegram" class="resp-sharing-button__link" href="https://telegram.me/share/url?text=yanchama - Diccionario de americanismos&url=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fyanchama" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--telegram resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M.707 8.475C.275 8.64 0 9.508 0 9.508s.284.867.718 1.03l5.09 1.897 1.986 6.38a1.102 1.102 0 0 0 1.75.527l2.96-2.41a.405.405 0 0 1 .494-.013l5.34 3.87a1.1 1.1 0 0 0 1.046.135 1.1 1.1 0 0 0 .682-.803l3.91-18.795A1.102 1.102 0 0 0 22.5.075L.706 8.475z"/></svg></div></div></a>
+<a title="Compartir en Pinterest" class="resp-sharing-button__link" href="https://pinterest.com/pin/create/button/?url=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fyanchama&media=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fyanchama&description=I. 1. Co. Lienzo que se obtiene de la corteza de ciertos árboles y que los indígenas del Amazonas pintan con colorantes vegetales. 2. Ec , Pe." target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--pinterest resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid"><svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.14.5C5.86.5 2.7 5 2.7 8.75c0 2.27.86 4.3 2.7 5.05.3.12.57 0 .66-.33l.27-1.06c.1-.32.06-.44-.2-.73-.52-.62-.86-1.44-.86-2.6 0-3.33 2.5-6.32 6.5-6.32 3.55 0 5.5 2.17 5.5 5.07 0 3.8-1.7 7.02-4.2 7.02-1.37 0-2.4-1.14-2.07-2.54.4-1.68 1.16-3.48 1.16-4.7 0-1.07-.58-1.98-1.78-1.98-1.4 0-2.55 1.47-2.55 3.42 0 1.25.43 2.1.43 2.1l-1.7 7.2c-.5 2.13-.08 4.75-.04 5 .02.17.22.2.3.1.14-.18 1.82-2.26 2.4-4.33.16-.58.93-3.63.93-3.63.45.88 1.8 1.65 3.22 1.65 4.25 0 7.13-3.87 7.13-9.05C20.5 4.15 17.18.5 12.14.5z"/></svg></div></div></a>
+<a title="Compartir en LinkedIn" class="resp-sharing-button__link" href="https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fyanchama&title=yanchama - Diccionario de americanismos&summary=I. 1. Co. Lienzo que se obtiene de la corteza de ciertos árboles y que los indígenas del Amazonas pintan con colorantes vegetales. 2. Ec , Pe.&source=https%3A%2F%2Fwww.asale.org%2Fdamer%2Fyanchama" target="_blank" rel="noopener" aria-label=""><div class="resp-sharing-button resp-sharing-button--linkedin resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
+<svg xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M6.5 21.5h-5v-13h5v13zM4 6.5C2.5 6.5 1.5 5.3 1.5 4s1-2.4 2.5-2.4c1.6 0 2.5 1 2.6 2.5 0 1.4-1 2.5-2.6 2.5zm11.5 6c-1 0-2 1-2 2v7h-5v-13h5V10s1.6-1.5 4-1.5c3 0 5 2.2 5 6.3v6.7h-5v-7c0-1-1-2-2-2z"/></svg></div></div></a></div></div>
+</div>
+<div data-nosnippet class="col-xs-12 col-md-4 bloque-txt">
+<h2 class="ayuda">Más información</h2>
+<div class="view-node-navigation"><ul class="menu"><li class="leaf d0"><a target="_blank" title="Prólogo de la obra" class="tooltip" href="https://www.asale.org/sites/default/files/Prologo_Diccionario_de_americanismos.pdf">Prólogo</a> de la obra</li><li class="leaf d0"><a target="_blank" title="Preliminares (abreviaturas) de la obra" class="tooltip" href="https://www.asale.org/sites/default/files/Abreviaturas_del_DA.pdf">Preliminares</a> (abreviaturas) de la obra</li></ul></div>
+
+    
+<div><h2 class="ayuda">Rueda de palabras</h2>
+<div>
+<ul class='rueda'><li><a href='/damer/yanapa'>yanapa</a></li><li><a href='/damer/yanapacu'>yanapacu</a></li><li><a href='/damer/yanapaña'>yanapaña</a></li><li><a href='/damer/yanarca'>yanarca</a></li><li><a href='/damer/yanasonco'>yanasonco</a></li><li><a href='/damer/yanavico'>yanavico</a></li><li><a href='/damer/yana-yana'>yana-yana</a></li><li><b>yanchama</b></li><li><a href='/damer/yancófila'>yancófila</a></li><li><a href='/damer/yancófilo'>yancófilo</a></li><li><a href='/damer/yanga'>yanga</a></li><li><a href='/damer/yanilla'>yanilla</a></li><li><a href='/damer/yaniqueque'>yaniqueque</a></li><li><a href='/damer/yankunú'>yankunú</a></li><li><a href='/damer/yanque'>yanque</a></li></ul></div>
+</div>
+</div>
+</div>
+</div>
+<div data-nosnippet class="clearfix" id="main">
+    <div data-nosnippet class="cog--mq mq-main">
+
+            <section class="section section--secondary o-section--large">
+  <div data-nosnippet class="container">
+
+    <h2 class="section__title" data-aos="fade-up" data-aos-offset="50" data-aos-delay="200" data-aos-duration="1000">
+      <span class="divider__title"></span>
+      También le interesará
+    </h2>
+
+    <div data-nosnippet class="row">
+
+      <div data-nosnippet class="col-xs-12 col-md-6 col-lg-3"
+           data-aos="fade-up"
+           data-aos-offset="150"
+           data-aos-delay="400"
+           data-aos-duration="800">
+          <div data-nosnippet class="views-element-container">
+<div data-nosnippet class="js-view-dom-id-8c04ccfd7f3b92f6c3aab78a869a5b7b26096c44d7cfadfba9fa077626f3453f vista">
+    
+    
+    
+
+    
+    
+    
+
+    
+
+  
+
+<div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/noticia/la-asociacion-de-academias-de-la-lengua-espanola-celebra-su-70o-aniversario-bajo-la">70 AÑOS DE ASALE</a></p>
+
+      <div data-nosnippet class="block-news__img img">
+      <a target="_self" title="Actos de celebración del 70 aniversario" href="/noticia/la-asociacion-de-academias-de-la-lengua-espanola-celebra-su-70o-aniversario-bajo-la">
+        <img class="b-lazy"
+             src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+             data-src="/sites/default/files/styles/tambien_interesa/public/2021-12/70%20anos%20asale.jpg?itok=kU8Y2JlT"
+             alt="Los reyes de España han presidido en el salón de actos de la RAE el solemne acto institucional conmemorativo del septuagésimo aniversario de la Asociación de Academias de la Lengua Española (ASALE). Foto: RAE. " />
+      </a>
+    </div>
+  
+      <span class="news__date">
+      
+    </span>
+  
+  <p class="block-news__title u-text-brandsecondary">
+    <a target="_self" title="Actos de celebración del 70 aniversario" href="/noticia/la-asociacion-de-academias-de-la-lengua-espanola-celebra-su-70o-aniversario-bajo-la">
+      Actos de celebración del 70 aniversario
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+
+  
+
+<div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/obras-academicas/clasicos-asale">Clásicos ASALE</a></p>
+
+      <div data-nosnippet class="block-news__img img">
+      <a target="_self" title="Conozca los títulos de toda la colección" href="/obras-academicas/clasicos-asale">
+        <img class="b-lazy"
+             src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+             data-src="/sites/default/files/styles/tambien_interesa/public/imagenes/articulos/Foto_La_Voz_de_Galicia_1_1.png?itok=nG30FJfh"
+             alt="Nuevos títulos de la colección Clásicos ASALE  " />
+      </a>
+    </div>
+  
+      <span class="news__date">
+      
+    </span>
+  
+  <p class="block-news__title u-text-brandsecondary">
+    <a target="_self" title="Conozca los títulos de toda la colección" href="/obras-academicas/clasicos-asale">
+      Conozca los títulos de toda la colección
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+
+        
+
+    
+    
+
+    
+</div>
+</div>
+
+      </div>
+
+
+      <div data-nosnippet class="col-xs-12 col-md-6 col-lg-8 u-border-left"
+           data-aos="fade-up"
+           data-aos-offset="150"
+           data-aos-delay="400"
+           data-aos-duration="800">
+          <div data-nosnippet class="views-element-container">
+<div data-nosnippet class="js-view-dom-id-85370cdf064634cff8240119e2e0d9a5a7386bb5bee16c7d525b7d986cfae390 vista">
+    
+    
+    
+
+    
+    
+    
+
+    
+<div data-nosnippet class="row">
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/lexicografia" hreflang="es">Lexicografía</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Cuarta convocatoria del Programa ASALE de becas de formación y colaboración destinado a las academias de la Asociación de Academias de la Lengua Española (ASALE) " href="/noticia/cuarta-convocatoria-del-programa-asale-de-becas-de-formacion-y-colaboracion-destinado-las">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/imagenes/articulos/centro_de_estudios_RAE_serrano.jpg?h=c9f93661&amp;itok=zfPMAJv-"
+               alt="Sede de la Escuela de Lexicografía (Serrano, 187-189) en Madrid (foto: RAE)">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2025-05-27T12:00:00Z">27 de Mayo de 2025</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Cuarta convocatoria del Programa ASALE de becas de formación y colaboración destinado a las academias de la Asociación de Academias de la Lengua Española (ASALE) " href="/noticia/cuarta-convocatoria-del-programa-asale-de-becas-de-formacion-y-colaboracion-destinado-las">
+      <span>Cuarta convocatoria del Programa ASALE de becas de formación y colaboración destinado a las academias de la Asociación de Academias de la Lengua Española (ASALE) </span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/academicos" hreflang="es">Académicos</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Carlos Martini, nuevo miembro de número de la Academia Paraguaya de la Lengua Española" href="/noticia/carlos-martini-nuevo-miembro-de-numero-de-la-academia-paraguaya-de-la-lengua-espanola">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/2021-11/Sede_APARLE.jpg?h=9e499333&amp;itok=BhYtrdjy"
+               alt="Sede de la Academia Paraguaya de la Lengua Española">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2025-01-13T12:00:00Z">13 de Enero de 2025</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Carlos Martini, nuevo miembro de número de la Academia Paraguaya de la Lengua Española" href="/noticia/carlos-martini-nuevo-miembro-de-numero-de-la-academia-paraguaya-de-la-lengua-espanola">
+      <span>Carlos Martini, nuevo miembro de número de la Academia Paraguaya de la Lengua Española</span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/obituarios" hreflang="es">Obituarios</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Fallece Tarsicio Herrera Zapién, miembro de la Academia Mexicana de la Lengua" href="/noticia/fallece-tarsicio-herrera-zapien-miembro-de-la-academia-mexicana-de-la-lengua">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/imagenes/academicos/Tarsicio_Herrera_Sapien_www.cultura.gob_.mx_.jpg?h=c9f93661&amp;itok=XE1zuFdY"
+               alt="Tarsicio Herrera Zapién, miembro de número de la Academia Mexicana de la Lengua. Foto: Secretaría de Cultura.">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2026-02-05T12:00:00Z">5 de Febrero de 2026</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Fallece Tarsicio Herrera Zapién, miembro de la Academia Mexicana de la Lengua" href="/noticia/fallece-tarsicio-herrera-zapien-miembro-de-la-academia-mexicana-de-la-lengua">
+      <span>Fallece Tarsicio Herrera Zapién, miembro de la Academia Mexicana de la Lengua</span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+      <div data-nosnippet class="col-md-12 col-lg-6"><div data-nosnippet class="block-news">
+  <p class="block-news__media pb-1"><a href="/comunicacion/noticias/academicos" hreflang="es">Académicos</a></p>
+
+  <div data-nosnippet class="block-news__img img">
+    <a title="Félix Julio Alfonso López ingresa en la Academia Cubana de la Lengua" href="/noticia/felix-julio-alfonso-lopez-ingresa-en-la-academia-cubana-de-la-lengua">
+                  <img class="b-lazy"
+               src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+               data-src="/sites/default/files/styles/rae_415_x_233/public/2026-02/F%C3%A9lix%20Julio%20Alfonso%20L%C3%B3pez_0.jpg?h=8b436e18&amp;itok=6lYXMiAr"
+               alt="Félix Julio Alfonso López">
+            </a>
+  </div>
+
+  <span class="news__date">
+    <time datetime="2026-02-04T12:00:00Z">4 de Febrero de 2026</time>
+
+  </span>
+
+  <p class="block-news__title u-text-brandsecondary">
+    <a title="Félix Julio Alfonso López ingresa en la Academia Cubana de la Lengua" href="/noticia/felix-julio-alfonso-lopez-ingresa-en-la-academia-cubana-de-la-lengua">
+      <span>Félix Julio Alfonso López ingresa en la Academia Cubana de la Lengua</span>
+
+    </a>
+  </p>
+  <div data-nosnippet class="divider divider__brand"></div>
+</div>
+</div>
+  </div>
+
+        
+
+    
+    
+
+    
+</div>
+</div>
+
+      </div>
+
+
+    </div>
+  </div>
+</section>
+
+            <section class="section o-section--medium">
+
+  <div data-nosnippet class="container">
+    <div data-nosnippet class="u-text-center">
+
+      <div data-nosnippet class="btn btn-up" data-aos="fade-up" data-aos-offset="50" data-aos-delay="200" data-aos-duration="1000">
+        <a href="#main" class="ancla">
+          <svg class="icon icon--small icon-black">
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#arrow-up"></use>
+          </svg>
+          <p class="btn__text">Arriba</p>
+        </a>
+      </div>
+
+    </div>
+  </div>
+
+</section>
+
+    </div>
+  </div>
+
+  
+  <footer id="footer" class="footer">
+  <div data-nosnippet class="container">
+    <div data-nosnippet class="pre-footer">
+
+      <p class="footer-privacidad">
+        REAL ACADEMIA ESPAÑOLA. Finalidades: Recopilación de información lingüística para la investigación, desarrollo, proyección y buen uso de la lengua española en el ámbito de la IA (proyecto LEIA). Derechos: tiene derecho a acceder, rectificar y suprimir sus datos, así como a otros derechos como se explica en la información adicional y detallada que se puede consultar en nuestra 
+        <span class="privacidad-link privacidad-link--inverse"><a href="/politica-de-privacidad-y-proteccion-de-los-datos-personales" target="_blank">política de privacidad</a>.</span>
+      </p>
+
+    </div>
+
+    <div data-nosnippet class="sub-footer">
+      <div data-nosnippet class="sub-footer__social">
+        <a title="Síganos en X" href="https://x.com/RAEinforma" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en X</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#twitter"></use>
+    </svg>
+</a>
+<a title="Síganos en Facebook"  href="https://www.facebook.com/RAE/" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en Facebook</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#facebook"></use>
+    </svg>
+</a>
+<a title="Visite nuestro Instagram" href="https://www.instagram.com/laraeinforma/" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Visite nuestro Instagram</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#instagram"></use>
+    </svg>
+</a>
+<a title="Síganos en TikTok" href="https://www.tiktok.com/@rae.informa" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en TikTok</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#tiktok"></use>
+    </svg>
+</a>
+<a title="Visite nuestras galerías" href="https://www.flickr.com/photos/raeinforma" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Visite nuestras galerías</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#flicker"></use>
+    </svg>
+</a>
+<a title="Síganos en Youtube" href="https://www.youtube.com/user/RAEInforma" rel="noopener" target="_blank">
+    <svg class="icon icon--medium">
+        <title>Síganos en Youtube</title>
+        <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#youtube"></use>
+    </svg>
+</a>
+
+<a title="Escuche nuestras listas de música" href="https://open.spotify.com/user/u0gt78txho8qqa5m843kkvxy2" rel="noopener" target="_blank">
+  <svg class="icon icon--medium">
+    <title>Escuche nuestras listas de música</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#spoty"></use>
+  </svg>
+</a>
+
+<a title="Síganos en Souncloud" href="https://soundcloud.com/real-academia-espanola" rel="noopener" target="_blank">
+  <svg class="icon icon--medium">
+    <title>Síganos en Soundcloud</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#soundcloud"></use>
+  </svg>
+</a>
+
+<a title="Contacte con nosotros" href="/contacto-rae">
+  <svg class="icon icon--medium">
+    <title>Contacte con nosotros</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#email"></use>
+  </svg>
+</a>
+
+      </div>
+
+      <div data-nosnippet class="sub-footer__link">
+        <a title="Visitar Fundación pro-RAE" href="/fundacion">Fundación pro-Rae</a>
+        <a title="Visitar web ASALE" href="https://www.asale.org/" rel="noopener" target="_blank">Asale</a>
+      </div>
+
+
+      <p class="footer__text">
+        Felipe IV, 5 - 28014 Madrid - Teléfono:
+        <a title="Teléfono contacto" href="tel:34914201478">+34 91 420 14 78</a>
+        <span class="ml-1 d-inline-block">
+          © Real Academia Española, 2019
+        </span>
+      </p>
+
+      
+
+<nav role="navigation" aria-labelledby="block-piedepagina" id="block-piedepagina" class="block block-menu navigation block-system-menublock menu--footer">
+      
+        
+
+                        <ul class="footer-list">
+                            <li class="footer-list__item">
+                <a href="https://rae.whistlelink.com" target="_blank">Canal del informante</a>
+                            </li>
+                </ul>
+    
+
+
+  </nav>
+
+    </div>
+
+  </div>
+</footer>
+
+<div data-nosnippet class="search-full-container">
+  <span class="menu-buttom__close">
+  <svg class="icon icon--xsmall icon-black">
+    <title>cerrar</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#close"></use>
+  </svg>
+</span>
+  <div data-nosnippet class="container">
+
+    <div data-nosnippet class="header__logo">
+      <div data-nosnippet class="img">
+        <a href="/" title="Inicio - Real Academia Española" rel="home" class="site-logo">
+          <svg class="icon icon-logo">
+            <title>Logo RAE</title>
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#logo-rae"></use>
+          </svg>
+        </a>
+      </div>
+    </div>
+    <div data-nosnippet class="row justify-content-center">
+      <div data-nosnippet class="col-12 col-md-8">
+        <h2 class="search__title">Buscador general de la RAE</h2>
+
+        <form class="search-block-form" data-drupal-selector="search-block-form" action="/search/node" method="get" id="search-block-form" accept-charset="UTF-8">
+  <div data-nosnippet class="js-form-item form-item js-form-type-search form-type-search js-form-item-keys form-item-keys form-no-label">
+      <label for="edit-keys" class="visually-hidden">Search</label>
+        <input title="Escriba lo que quiere buscar." placeholder="Buscar en la web" data-drupal-selector="edit-keys" type="search" id="edit-keys" name="keys" value="" size="15" maxlength="128" class="form-search" />
+
+        </div>
+<div data-nosnippet data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions"><input alt="Buscar en la web" data-drupal-selector="edit-submit" type="image" id="edit-submit" name="op" src="/themes/custom/front/src/assets/images/lupa.svg" class="image-button js-form-submit form-submit" />
+</div>
+
+</form>
+
+      </div>
+    </div>
+  </div>
+</div>
+
+<div data-nosnippet class="dle-full-container">
+  <span class="menu-buttom__close">
+  <svg class="icon icon--xsmall icon-black">
+    <title>cerrar</title>
+    <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#close"></use>
+  </svg>
+</span>
+  <div data-nosnippet class="contenedor-full">
+
+    <div data-nosnippet class="container">
+      <div data-nosnippet class="row justify-content-between">
+
+        <div data-nosnippet class="col-xs-12 col-lg-7">
+          <div data-nosnippet class="diccionarios-container">
+            <h2 class="diccionarios-container__title">Diccionarios</h2>
+            <form class="diccionarios-form" data-drupal-selector="diccionarios-form" action="/" method="post" id="diccionarios-form" accept-charset="UTF-8">
+  <div data-nosnippet id="edit-diccionario"><div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dle" type="radio" id="edit-diccionario-dle" name="diccionario" value="dle" checked="checked" class="form-radio" />
+
+        <label for="edit-diccionario-dle" class="option">Diccionario de la lengua española</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dpd" type="radio" id="edit-diccionario-dpd" name="diccionario" value="dpd" class="form-radio" />
+
+        <label for="edit-diccionario-dpd" class="option">Diccionario panhispánico de dudas</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dpej" type="radio" id="edit-diccionario-dpej" name="diccionario" value="dpej" class="form-radio" />
+
+        <label for="edit-diccionario-dpej" class="option">Diccionario panhispánico del español jurídico</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-dhle" type="radio" id="edit-diccionario-dhle" name="diccionario" value="dhle" class="form-radio" />
+
+        <label for="edit-diccionario-dhle" class="option">Diccionario histórico de la lengua española</label>
+      </div>
+<div data-nosnippet class="js-form-item form-item js-form-type-radio form-type-radio js-form-item-diccionario form-item-diccionario">
+        <input aria-label="Seleccionar diccionario" data-drupal-selector="edit-diccionario-damer" type="radio" id="edit-diccionario-damer" name="diccionario" value="damer" class="form-radio" />
+
+        <label for="edit-diccionario-damer" class="option">Diccionario de americanismos</label>
+      </div>
+</div>
+<fieldset data-drupal-selector="edit-caja" id="edit-caja" class="form-item js-form-wrapper form-wrapper">
+      <legend>
+    <span class="fieldset-legend"></span>
+  </legend>
+  <div data-nosnippet class="fieldset-wrapper">
+            <div data-nosnippet class="js-form-item form-item js-form-type-textfield form-type-textfield js-form-item-termino form-item-termino form-no-label">
+        <input aria-label="Término" data-drupal-selector="edit-termino" type="text" id="edit-termino" name="termino" value="" size="60" maxlength="128" placeholder="Escriba el término" class="form-text required" required="required" aria-required="true" />
+
+        </div>
+<input class="icon--small image-button js-form-submit form-submit" alt="Escriba el término" data-drupal-selector="edit-submit" type="image" id="edit-submit--2" name="op" src="/themes/custom/front/src/assets/images/lupa.svg" />
+
+          </div>
+</fieldset>
+<div data-nosnippet class="logo"><div data-nosnippet data-drupal-selector="edit-lacaixa-modal" data-drupal-states="{&quot;visible&quot;:[{&quot;:input[name=\u0022diccionario\u0022]&quot;:{&quot;value&quot;:&quot;dle&quot;}}]}" id="edit-lacaixa-modal" class="js-form-wrapper form-wrapper"><a title="Fundación “la Caixa”" rel="noopener" target="_blank" href="https://fundacionlacaixa.org/es/home"><img src="/themes/custom/front/src/assets/svg/logo-fundacion-caixa.svg" alt="Logo Obra social “la Caixa”"></a></div>
+</div><input autocomplete="off" data-drupal-selector="form-de5lmhtqydrxzr6w-xriydfdwu2h6myrcglqfxbmgny" type="hidden" name="form_build_id" value="form-DE5LmhtqyDrxzr6w-XrIYdfDWU2H6myrcglqFxbmgNY" />
+<input data-drupal-selector="edit-diccionarios-form" type="hidden" name="form_id" value="diccionarios_form" />
+<div data-nosnippet data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions--3"></div>
+
+</form>
+
+          </div>
+        </div>
+        <div data-nosnippet class="col-xs-12 col-lg-4">
+          <div data-nosnippet class="dudas-container">
+            <h2 class="dudas-container__title">Dudas rápidas</h2>
+            <form class="dudas-form-modal" data-drupal-selector="dudas-form-modal" action="/" method="post" id="dudas-form-modal" accept-charset="UTF-8">
+  <fieldset data-drupal-selector="edit-caja-dudas-modal" id="edit-caja-dudas-modal" class="form-item js-form-wrapper form-wrapper">
+      <legend>
+    <span class="fieldset-legend"></span>
+  </legend>
+  <div data-nosnippet class="fieldset-wrapper">
+            <div data-nosnippet class="js-form-item form-item js-form-type-textfield form-type-textfield js-form-item-duda-modal form-item-duda-modal form-no-label">
+        <input aria-label="Término" data-drupal-selector="edit-duda-modal" type="text" id="edit-duda-modal" name="duda_modal" value="" size="60" maxlength="128" placeholder="Escriba las palabras clave" class="form-text required" required="required" aria-required="true" />
+
+        </div>
+<input class="icon--small image-button js-form-submit form-submit" alt="Buscar duda" data-drupal-selector="edit-submit-modal" type="image" id="edit-submit-modal" name="op" src="/themes/custom/front/src/assets/images/lupa.svg" />
+
+          </div>
+</fieldset>
+<input autocomplete="off" data-drupal-selector="form-fchspnlzijqwdzudyjfxurdyced1d5vohfzqucdv8co" type="hidden" name="form_build_id" value="form-FcHsPNlziJQwdzUDYJfxURDYced1d5VOHfzQUCdv8Co" />
+<input data-drupal-selector="edit-dudas-form-modal" type="hidden" name="form_id" value="dudas_form_modal" />
+<div data-nosnippet data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions--5"></div>
+
+</form>
+
+          </div>
+        </div>
+      </div>
+
+      <div data-nosnippet class="recursos-container">
+        <h2 class="title__medium text-center mb-7">
+          Otros Recursos
+          <svg class="icon icon--xsmall icon-black">
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#plus"></use>
+          </svg>
+          <svg class="icon icon--xsmall icon-black hidden">
+            <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#menos"></use>
+          </svg>
+        </h2>
+        <div data-nosnippet class="lista-recursos-container">
+          
+
+
+    
+          <ul class="lista-recursos" >
+    
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Diccionarios</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://dle.rae.es/">Diccionario de la lengua española</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/dpd/">Diccionario panhispánico de dudas</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://dpej.rae.es/">Diccionario panhispánico del español jurídico</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="/dhle">Diccionario histórico de la lengua española</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.asale.org/damer/">Diccionario de americanismos</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/diccionario-estudiante/" title="Diccionario del estudiante">Diccionario del estudiante</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/tdhle/" title="Tesoro de diccionarios históricos de la lengua">Tesoro de diccionarios históricos de la lengua</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/DA.html">Diccionario de autoridades</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://apps.rae.es/ntlle/SrvltGUISalirNtlle">Nuevo tesoro lexicográfico</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/ntllet/SrvltGUILoginNtlletPub">Mapa de diccionarios</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/DH1936.html">Diccionario histórico (1933-1936)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/DH.html">Diccionario histórico (1960-1996)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/drae2001/">Diccionario de la lengua española (2001)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/desen/">Diccionario esencial (2006)</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/formulario-de-la-unidad-interactiva-del-diccionario" title="Envíe las propuestas y sugerencias externas relacionadas con el «Diccionario de la lengua española»">Unidad Interactiva del Diccionario (UNIDRAE)</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Banco de datos</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/corpes/">CORPES XXI</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/CNDHE/">CDH</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://corpus.rae.es/creanet.html">CREA</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/crea-anotado/" title="CREA anotado">CREA anotado</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://corpus.rae.es/cordenet.html">CORDE</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/fichero.html">Fichero general</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.asale.org/corpus-asale/">Corpus ASALE</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Gramática</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://aplica.rae.es/grweb/cgi-bin/buscar.cgi">Nueva gramática de la lengua española</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/gtg/">Glosario de términos gramaticales</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/sites/default/files/Gramatica_RAE_1771_reducida.pdf">Primera gramática</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/gram%C3%A1tica-b%C3%A1sica/" title="Nueva gramática básica de la lengua española">Nueva gramática básica de la lengua española</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Ortografía</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://aplica.rae.es/orweb/cgi-bin/buscar.cgi">Ortografía 2010</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="/sites/default/files/Ortografia_RAE_1741_reducida.pdf">Primera ortografía</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/ortograf%C3%ADa-b%C3%A1sica/" title="Ortografía básica de la lengua española">Ortografía básica de la lengua española</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Biblioteca</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca/biblioteca-academica">Biblioteca académica</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca/legado-antonio-rodriguez-monino-y-maria-brey">Legado Rodríguez-Moñino</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca/legado-damaso-alonso">Legado Dámaso Alonso</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/biblioteca-digital" title="Biblioteca Digital">Biblioteca Digital</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Archivo</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://archivo.rae.es/">Fondo institucional</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://archivo.rae.es/index.php/coleccion-de-autografos-de-pedro-antonio-de-alarcon">Colección P. A. de Alarcón</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://archivo.rae.es/zorrilla/">Zorrilla</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://www.rae.es/manuscritos-para-la-segunda-edicion-del-diccionario-de-autoridades">2.ª edición del «Diccionario de autoridades»</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://archivo.rae.es/fichero-de-hilo">Fichero de hilo</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Boletines</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://revistas.rae.es/bilrae/">BILRAE</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://revistas.rae.es/brae">BRAE</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span title="Recursos académicos de apoyo para el lenguaje claro">Lenguaje claro</span>
+          </div>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Enclave</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://enclavedeciencia.rae.es/inicio">Enclave de Ciencia</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+          <li class="menu-list__item" >
+
+                  <div data-nosnippet class="listado__item mb-6">
+           <span>Enlaces externos</span>
+          </div>
+        
+                      
+          <ul>
+    
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="http://asines.org/">Atlas sintáctico del español</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/dhecan.html">Diccionario Histórico del Español de Canarias</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://webfrl.rae.es/CORLEXIN.html">Corpus Léxico de Inventarios</a>
+        
+              </li>
+          <li class="menu-list__item" >
+
+                    <svg class="icon icon--xsmall">
+              <use xlink:href="/themes/custom/asale/assets/svg/sprite/sprite.svg#icono-enlace"></use>
+            </svg>
+           <a href="https://lla.unileon.es/" title="Léxico leonés actual">Léxico leonés actual</a>
+        
+              </li>
+    
+  </ul>
+  
+              </li>
+    
+  </ul>
+  
+
+
+        </div>
+      </div>
+
+
+    </div>
+
+  </div>
+</div>
+
+</div>
+
+  </div>
+
+      
+
+    </div>
+
+    
+
+
+  <script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script src="/sites/default/files/js/js_7hSOT9HVKxMvGlrclR4TDcqOUtAR-0e88Vkq_P_PROE.js"></script>\n<script src="/damer/js/20210406.js"></script>
+<!--[if IE]>
+<style>
+#deletex{ display:none;}
+</style>
+<![endif]-->
+</body>
+<script>
+window.cat='EXTERNO';window.acc='www.asale.org/damer/yanchama';window.eti='https://www.asale.org/damer/asopado';
+</script>
+</html>

--- a/tests/cogs/test_damer.py
+++ b/tests/cogs/test_damer.py
@@ -201,3 +201,37 @@ class TestDamer:
         )
         assert entrada.expresiones[0] == want_expr
         assert entrada.busca_expresión('~ ojé') == want_expr
+
+    def test_many_expressions(self, fetch_parsed_html):
+        entradas = Buscador.parsear_resultados('ir', fetch_parsed_html('ir.html'))
+        assert len(entradas) == 1
+        entrada = entradas[0]
+        assert len(entrada.expresiones) == 282
+        phrase = DamerDictionary._generate_target_word_and_phrase('írsele los humos a la cabeza'.split())[1]
+        assert entrada.busca_expresión(phrase).texto_entrada_raw == 'írsele los humos a la cabeza. RD, PR, Ch. írsele los humos.'
+        phrase = DamerDictionary._generate_target_word_and_phrase('no irse chancho con mazorca'.split())[1]
+        assert entrada.busca_expresión(phrase).texto_entrada_raw == 'no ~se chancho con mazorca. loc. verb. Ho, ES. Darse cuenta una persona de todo lo que sucede. pop.'
+        phrase = DamerDictionary._generate_target_word_and_phrase('no ir a ningún Pereira'.split())[1]
+        want_expr = Expresión(
+            índice='a. ǁ',
+            texto_entrada='**no **~** a ningún Pereira.** fr. prov. _Co:O._ Indica que si algo se hace de forma perezosa y desinteresada no se logrará.',
+            texto_entrada_raw='no ~ a ningún Pereira. fr. prov. Co:O. Indica que si algo se hace de forma perezosa y desinteresada no se logrará.',
+            subsignificados=[],
+            marcador='◪'
+        )
+        assert entrada.busca_expresión(phrase) == want_expr
+        assert entrada.busca_expresión('no ~ a ningún pereira') == want_expr
+        assert entrada.busca_expresión('NO ~ A NINGÚN PEREIRA') == want_expr
+        want_expr = Expresión(
+            índice='k. ǁ',
+            texto_entrada='~** a los bifes.**',
+            texto_entrada_raw='~ a los bifes.',
+            subsignificados=[
+                ('i.', 'loc. verb. _Ar_, _Ur._ Enfrentarse con decisión a una situación o dificultad. pop.'),
+                ('ii.', '_Ur._ Agredir físicamente a _alguien_. pop + cult → espon.'),
+                ('iii.', '_Ur._ _En una relación amorosa_, buscar un acercamiento físico. pop + cult → espon.')
+            ],
+            marcador=''
+        )
+        assert entrada.busca_expresión('~ a los bifes') == want_expr
+        assert entrada.expresiones[15] == want_expr

--- a/tests/cogs/test_damer.py
+++ b/tests/cogs/test_damer.py
@@ -1,4 +1,15 @@
-from cogs.damer import DamerDictionary
+import pytest
+import os
+
+from cogs.damer import DamerDictionary, Buscador, Acepción, Expresión, ExcepciónDNE
+
+@pytest.fixture
+def fetch_parsed_html():
+    def _fetch_parsed_html(filename: str):
+        html_path = os.path.join('tests', 'cogs', 'damer_sample_htmls', filename)
+        with open(html_path, 'r') as html_file:
+            return html_file.read()
+    return _fetch_parsed_html
 
 
 class TestDamer:
@@ -28,3 +39,165 @@ class TestDamer:
         assert DamerDictionary._generate_target_word_and_phrase('no irse chancho con mazorca'.split()) == ('ir', 'no ~se chancho con mazorca')
         assert DamerDictionary._generate_target_word_and_phrase('írsela campechaneando'.split()) == ('ir', 'írsela campechaneando')
         assert DamerDictionary._generate_target_word_and_phrase('ir de pinch hitter'.split()) == ('ir', '~ de pinch hitter')
+
+    def test_primary_etymology(self, fetch_parsed_html):
+        # Test primary etymology without formatting
+        entradas = Buscador.parsear_resultados('living', fetch_parsed_html('living.html'))
+        assert len(entradas) == 1
+        entrada = entradas[0]
+        assert entrada.encabezado == '_living._'
+        assert entrada.etimología == '(Voz inglesa).'
+        assert len(entrada.acepciones) == 1
+        assert entrada.acepciones[0] == Acepción(
+            índice_primario='I.',
+            índice_secundario='1.',
+            texto_entrada='m. _Cu_, _Bo_, _Ch_, _Py._ Juego de sofá y sillones de una sala de estar.',
+            texto_entrada_raw='m. Cu, Bo, Ch, Py. Juego de sofá y sillones de una sala de estar.'
+        )
+        assert len(entrada.expresiones) == 1
+        assert entrada.expresiones[0] == Expresión(
+            índice='a. ǁ',
+            texto_entrada='~** comedor.** m. _Ni_, _Cu_, _Bo_, _Ch_, _Py_, _Ar._ Habitación de una casa en la que se hace la vida social.',
+            texto_entrada_raw='~ comedor. m. Ni, Cu, Bo, Ch, Py, Ar. Habitación de una casa en la que se hace la vida social.',
+            subsignificados=[],
+            marcador='■'
+        )
+        assert entrada.expresiones[0].expresión == '~ comedor'
+
+        # Test primary etymology with italics
+        entradas = Buscador.parsear_resultados('country', fetch_parsed_html('country.html'))
+        assert len(entradas) == 1
+        entrada = entradas[0]
+        assert entrada.encabezado == '_country._'
+        assert entrada.etimología == '(Voz inglesa_, campo_).'
+        assert len(entrada.acepciones) == 0
+        assert len(entrada.expresiones) == 1
+        want_expr = Expresión(
+            índice='a. ǁ',
+            texto_entrada='~** club.** m. _EU_, _Ni_, _PR_, _Ve_, _Ec_, _Ch_, _Py_. Club campestre de actividades deportivas, _especialmente de golf_.',
+            texto_entrada_raw='~ club. m. EU, Ni, PR, Ve, Ec, Ch, Py. Club campestre de actividades deportivas, especialmente de golf.',
+            subsignificados=[],
+            marcador='■'
+        )
+        assert entrada.expresiones[0] == want_expr
+        assert entrada.expresiones[0].expresión == '~ club'
+        assert entrada.busca_expresión('~ club') == want_expr
+        assert entrada.busca_expresión('~ dne') == None
+
+    def test_dne(self, fetch_parsed_html):
+        with pytest.raises(ExcepciónDNE) as excDNE:
+            entradas = Buscador.parsear_resultados('asd', fetch_parsed_html('dne.html'))
+        assert str(excDNE.value) == '''Aviso: La palabra **asd** no está en el Diccionario. Las entradas que se muestran a continuación podrían estar relacionadas:
+
+[asa](https://www.asale.org/damer/damer/asa) (asa)
+[así](https://www.asale.org/damer/damer/así) (así)'''
+
+    def test_etymology_in_numerals(self, fetch_parsed_html):
+        entradas = Buscador.parsear_resultados('cajeta', fetch_parsed_html('cajeta.html'))
+        assert len(entradas) == 1
+        entrada = entradas[0]
+        assert entrada.encabezado == 'cajeta.'
+        assert not entrada.etimología
+        assert len(entrada.acepciones) == 15
+        assert entrada.acepciones[0] == Acepción(
+            índice_primario='I. (Del nahua _caxitl,_ escudilla).',
+            índice_secundario='1.',
+            texto_entrada='f. _Mx_, _Gu_, _Cu_, _RD_, _PR_, _Pe_;_ Ec,_ obsol;_ Ho_, pop. Caja en que se ponen o venden dulces, jalea o turrón de diversas formas, según el molde que se use.',
+            texto_entrada_raw='f. Mx, Gu, Cu, RD, PR, Pe; Ec, obsol; Ho, pop. Caja en que se ponen o venden dulces, jalea o turrón de diversas formas, según el molde que se use.'
+        )
+        assert entrada.acepciones[1] == Acepción(
+            índice_primario='',
+            índice_secundario='2.',
+            texto_entrada='_Mx_, _Gu_, _Pa_, _Pe_;_ Ho_, pop. Dulce de leche, _generalmente de cabra_, quemada con azúcar, y de consistencia similar al turrón.',
+            texto_entrada_raw='Mx, Gu, Pa, Pe; Ho, pop. Dulce de leche, generalmente de cabra, quemada con azúcar, y de consistencia similar al turrón.'
+        )
+        # Con vínculo
+        print(entrada.acepciones[4])
+        assert entrada.acepciones[4] == Acepción(
+            índice_primario='',
+            índice_secundario='5.',
+            texto_entrada='_Ni_, _CR._ Dulce similar al turrón, elaborado con [panela](https://www.asale.org/damer/panela), dulce de leche o leche en polvo; puede añadírsele algún fruto seco rallado, _especialmente_ _coco._',
+            texto_entrada_raw='Ni, CR. Dulce similar al turrón, elaborado con panela, dulce de leche o leche en polvo; puede añadírsele algún fruto seco rallado, especialmente coco.'
+        )
+        assert entrada.acepciones[7] == Acepción(
+            índice_primario='III.',
+            índice_secundario='1.',
+            texto_entrada='f. _Ve:O._ Caja pequeña, _generalmente con forma de cono truncado, hecha de cuerno de res o de otros materiales_, utilizada para guardar el chimó.',
+            texto_entrada_raw=' f. Ve:O. Caja pequeña, generalmente con forma de cono truncado, hecha de cuerno de res o de otros materiales, utilizada para guardar el chimó.'
+        )
+        assert entrada.acepciones[14] == Acepción(
+            índice_primario='VIII. (De la sigla _KGB_, policía secreta de la antigua Unión Soviética).',
+            índice_secundario='1.',
+            texto_entrada='f. _Ho._ Policía secreta de la antigua Unión Soviética. cult ^ fest.',
+            texto_entrada_raw='f. Ho. Policía secreta de la antigua Unión Soviética. cult ^ fest.'
+        )
+        assert len(entrada.expresiones) == 3
+        assert entrada.expresiones[0] == Expresión(
+            índice='a. ǁ',
+            texto_entrada='~** de Celaya.** loc. sust. _Mx._ Conciencia exagerada de la propia valía, complejo de superioridad.',
+            texto_entrada_raw='~ de Celaya. loc. sust. Mx. Conciencia exagerada de la propia valía, complejo de superioridad.',
+            subsignificados=[],
+            marcador='□'
+        )
+        want_expr = Expresión(
+            índice='b. ǁ',
+            texto_entrada='**de **~**.** loc. adj. _RD._ _Referido a objeto_, nuevo, sin estrenar.',
+            texto_entrada_raw='de ~. loc. adj. RD. Referido a objeto, nuevo, sin estrenar.',
+            subsignificados=[],
+            marcador=''
+        )
+        assert entrada.expresiones[1] == want_expr
+        assert entrada.expresiones[2] == Expresión(
+            índice='▶',
+            texto_entrada='**chupar **~;** dar **~;** tener **~**, cuchillo y guaro**.',
+            texto_entrada_raw='chupar ~; dar ~; tener ~, cuchillo y guaro.',
+            subsignificados=[],
+            marcador=''
+        )
+        assert entrada.busca_expresión('de ~') == want_expr
+
+    def test_multi_entradas(self, fetch_parsed_html):
+        entradas = Buscador.parsear_resultados('asopado', fetch_parsed_html('asopado.html'))
+        assert len(entradas) == 2
+        entrada1 = entradas[0]
+        assert len(entrada1.expresiones) == 0
+        assert len(entrada1.acepciones) == 1
+        assert entrada1.encabezado == 'asopado.'
+        assert entrada1.acepciones[0] == Acepción(
+            índice_primario='I.',
+            índice_secundario='1.',
+            texto_entrada='m. _Pa._ Plato de arroz cocido con carne o pollo y algunas verduras, con la apariencia de una sopa espesa.',
+            texto_entrada_raw='m. Pa. Plato de arroz cocido con carne o pollo y algunas verduras, con la apariencia de una sopa espesa.'
+        )
+        entrada2 = entradas[1]
+        assert len(entrada2.expresiones) == 0
+        assert len(entrada2.acepciones) == 1
+        assert entrada2.encabezado == 'asopado, -a.'
+        assert entrada2.acepciones[0] == Acepción(
+            índice_primario='I.',
+            índice_secundario='1.',
+            texto_entrada='adj/sust. _Ch._ _Referido a persona_, escasa de entendimiento y lenta para reaccionar. pop + cult → espon ^ desp.',
+            texto_entrada_raw='adj/sust. Ch. Referido a persona, escasa de entendimiento y lenta para reaccionar. pop + cult → espon ^ desp.'
+        )
+
+    def test_equivalencias(self, fetch_parsed_html):
+        entradas = Buscador.parsear_resultados('yanchama', fetch_parsed_html('yanchama.html'))
+        assert len(entradas) == 1
+        entrada = entradas[0]
+        assert len(entrada.acepciones) == 4
+        assert len(entrada.expresiones) == 1
+        assert entrada.acepciones[1] == Acepción(
+            índice_primario='',
+            índice_secundario='2.',
+            texto_entrada='_Ec_, _Pe._ Árbol de hasta 30 m de altura, de tronco recto con la corteza exterior gris claro, copa redonda o irregular, poco densa, hojas simples, alternas, de borde enteros, flores amarillas, frutos globosos, con el extremo apical en forma de estrella, de color verde, tornándose amarillos al madurar. (Moraceae; _Poulsenia armata_). ([llanchama](https://www.asale.org/damer/llanchama)). ◆ **cucuá**; **ñumi**.',
+            texto_entrada_raw='Ec, Pe. Árbol de hasta 30 m de altura, de tronco recto con la corteza exterior gris claro, copa redonda o irregular, poco densa, hojas simples, alternas, de borde enteros, flores amarillas, frutos globosos, con el extremo apical en forma de estrella, de color verde, tornándose amarillos al madurar. (Moraceae; Poulsenia armata). (llanchama). ◆ cucuá; ñumi.'
+        )
+        want_expr = Expresión(
+            índice='a. ǁ',
+            texto_entrada='~** ojé.** f. _Co._ Árbol de hasta 30 m de altura, de corteza exterior blanca o grisácea, hojas simples y alternas, de bordes enteros y frutos globosos; de su corteza se obtiene la tela para hacer la yanchama. (Moraceae; _Ficus glabrata_). ◆ **ojé**.',
+            texto_entrada_raw='~ ojé. f. Co. Árbol de hasta 30 m de altura, de corteza exterior blanca o grisácea, hojas simples y alternas, de bordes enteros y frutos globosos; de su corteza se obtiene la tela para hacer la yanchama. (Moraceae; Ficus glabrata). ◆ ojé.',
+            subsignificados=[],
+            marcador='■'
+        )
+        assert entrada.expresiones[0] == want_expr
+        assert entrada.busca_expresión('~ ojé') == want_expr


### PR DESCRIPTION
Various bug fixes and internal improvements:
- Add U+200B zero-width space at beginning of indents to allow proper spacing for first elements in embed
- Change spacing character to U+2003 since discord embeds stopped handling the previous one correctly
- Store raw (unformatted) text for entry elements to improve phrase lookups
- Fix spacing when displaying expressions starting with ▶
- properly fetch etymology when it's tied to the entire entry and not just a subset of definitions
- break phrase lookup into separate method for easier unit testing
- refactor part of the embed generation for cleaner code
- remove irrelevant print statement
- add more unit tests