### PR TITLE
feat: Add percentage-gated hardcore mode for Spanish server

### DIFF
--- a/cogs/general.py
+++ b/cogs/general.py
@@ -367,19 +367,20 @@ class General(commands.Cog):
                 return
 
             # Check if user already meets the threshold
+            lang_name = {'es': 'Spanish', 'en': 'English'}.get(target_lang, target_lang)
             current_pct = hf.get_language_percentage(ctx.author.id, ctx.guild, target_lang)
             already_past = current_pct is not None and current_pct >= threshold
 
             if already_past:
                 message = (
-                    f"You already have **{current_pct}%** in **{target_lang}** "
+                    f"You already have **{current_pct}%** in **{lang_name}** "
                     f"(threshold: {threshold}%), so hardcore would have no lock-in effect. "
                     f"Enable anyway?"
                 )
             else:
                 message = (
                     f"You are about to enable hardcore mode locked to **{threshold}%** "
-                    f"in **{target_lang}**. You will **not** be able to remove it until "
+                    f"in **{lang_name}**. You will **not** be able to remove it until "
                     f"you reach that percentage. Mods cannot help you remove it either. "
                     f"Are you sure?"
                 )
@@ -403,7 +404,7 @@ class General(commands.Cog):
             await utils.safe_send(
                 ctx,
                 f"Hardcore enabled! You must reach **{threshold}%** in "
-                f"**{target_lang}** before you can remove it."
+                f"**{lang_name}** before you can remove it."
             )
             return
 
@@ -418,6 +419,7 @@ class General(commands.Cog):
                 if user_hc and 'threshold' in user_hc:
                     # User has a stored threshold — check if they meet it
                     target_lang = user_hc['target_lang']
+                    lang_name = {'es': 'Spanish', 'en': 'English'}.get(target_lang, target_lang)
                     required = user_hc['threshold']
                     current_pct = hf.get_language_percentage(ctx.author.id, ctx.guild, target_lang)
                     if current_pct is None:
@@ -427,7 +429,7 @@ class General(commands.Cog):
                         await utils.safe_send(
                             ctx,
                             f"You can't remove hardcore yet. You need **{required}%** in "
-                            f"**{target_lang}** but you're currently at **{current_pct}%**."
+                            f"**{lang_name}** but you're currently at **{current_pct}%**."
                         )
                         return
                     else:
@@ -436,7 +438,7 @@ class General(commands.Cog):
                         await utils.safe_send(
                             ctx,
                             f"Congrats on reaching your goal of **{required}%**! "
-                            f"Your current level is **{current_pct}%** in **{target_lang}**. "
+                            f"Your current level is **{current_pct}%** in **{lang_name}**. "
                             f"I've removed hardcore from you."
                         )
                         del self.bot.db['hardcore'][guild_id]['users'][user_id]

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -23,7 +23,7 @@ dir_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 BLACKLIST_CHANNEL_ID = 533863928263082014
 MODCHAT_SERVER_ID = 257984339025985546
 JP_SERVER_ID = 189571157446492161
-SP_SERVER_ID = 731403448502845501  # TESTING: was 243838819743432704
+SP_SERVER_ID = 243838819743432704
 CH_SERVER_ID = 266695661670367232
 CL_SERVER_ID = 320439136236601344
 RY_SERVER_ID = 275146036178059265
@@ -316,7 +316,7 @@ class General(commands.Cog):
 
     @commands.group(aliases=['hc'], invoke_without_command=True)
     @commands.guild_only()
-    @commands.check(lambda ctx: ctx.guild.id in [SP_SERVER_ID, CH_SERVER_ID, CL_SERVER_ID, 731403448502845501] if ctx.guild else False)
+    @commands.check(lambda ctx: ctx.guild.id in [SP_SERVER_ID, CH_SERVER_ID, CL_SERVER_ID] if ctx.guild else False)
     async def hardcore(self, ctx: commands.Context, threshold: Optional[int] = None):
         """Adds/removes the hardcore role from you.
 
@@ -326,8 +326,8 @@ class General(commands.Cog):
         role = ctx.guild.get_role(
             self.bot.db['hardcore'][str(ctx.guild.id)]['role'])
         if ctx.guild.id == SP_SERVER_ID:
-            learning_eng = ctx.guild.get_role(1472535759259963594)  # TESTING: was 247021017740869632
-            learning_sp = ctx.guild.get_role(1472535805191917649)  # TESTING: was 297415063302832128
+            learning_eng = ctx.guild.get_role(247021017740869632)
+            learning_sp = ctx.guild.get_role(297415063302832128)
             if learning_eng not in ctx.author.roles and learning_sp not in ctx.author.roles:
                 await utils.safe_send(ctx, "You need to have a learning role to use this command.")
                 return
@@ -345,8 +345,8 @@ class General(commands.Cog):
                 return
 
             # Determine target language from learning role
-            learning_eng = ctx.guild.get_role(1472535759259963594)  # TESTING: was 247021017740869632
-            learning_sp = ctx.guild.get_role(1472535805191917649)  # TESTING: was 297415063302832128
+            learning_eng = ctx.guild.get_role(247021017740869632)
+            learning_sp = ctx.guild.get_role(297415063302832128)
             if learning_sp in ctx.author.roles:
                 target_lang = 'es'
             elif learning_eng in ctx.author.roles:

--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -321,12 +321,13 @@ class Stats(commands.Cog):
         if sorted_langs:
             value = ''
             counter = 0
+            lang_total = sum(lang_count.values())
             for lang_tuple in sorted_langs:
                 if lang_tuple[0] not in self.lang_codes_dict:
                     continue
-                percentage = hf.get_language_percentage(user_id, ctx.guild, lang_tuple[0])
-                if percentage is None:
+                if lang_total == 0:
                     continue
+                percentage = round((lang_tuple[1] / lang_total) * 100, 1)
                 if (counter in [0, 1] and percentage > 2.5) or (percentage > 5):
                     value += f"**{self.lang_codes_dict[lang_tuple[0]]}**: {percentage}%\n"
                 if counter == 5:

--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -321,13 +321,12 @@ class Stats(commands.Cog):
         if sorted_langs:
             value = ''
             counter = 0
-            total = 0
-            for lang_tuple in sorted_langs:
-                total += lang_tuple[1]
             for lang_tuple in sorted_langs:
                 if lang_tuple[0] not in self.lang_codes_dict:
                     continue
-                percentage = round((lang_tuple[1] / total) * 100, 1)
+                percentage = hf.get_language_percentage(user_id, ctx.guild, lang_tuple[0])
+                if percentage is None:
+                    continue
                 if (counter in [0, 1] and percentage > 2.5) or (percentage > 5):
                     value += f"**{self.lang_codes_dict[lang_tuple[0]]}**: {percentage}%\n"
                 if counter == 5:

--- a/cogs/utils/helper_functions.py
+++ b/cogs/utils/helper_functions.py
@@ -268,6 +268,18 @@ def get_stats_per_channel(member_id: int, guild: discord.Guild, desired_stat: st
         return total_msgs_month, total_msgs_week, message_count, emoji_count, lang_count
 
 
+def get_language_percentage(member_id: int, guild: discord.Guild, language: str) -> Optional[float]:
+    """Returns the percentage (0-100) of a user's messages detected as `language` over the last 30 days.
+    Returns None if no language data exists."""
+    lang_count = get_stats_per_channel(member_id, guild, desired_stat='lang')
+    if not lang_count:
+        return None
+    total = sum(lang_count.values())
+    if total == 0:
+        return None
+    return round((lang_count.get(language, 0) / total) * 100, 1)
+
+
 def count_activity(member_id: int, guild: discord.Guild) -> int:
     """Returns an integer value for activity in a server in the last month"""
     activity_score = 0


### PR DESCRIPTION
Users on the Spanish server can now lock themselves into hardcore with a percentage threshold   
  (e.g. ;hc 50). They can't remove the role until they reach that percentage in their target
  language. Using ;hc without a number keeps the existing free-toggle behavior.

  - Confirmation prompt before locking in
  - Users can raise their threshold but not lower it
  - Congratulates users when they meet their goal and remove hardcore
  - Adds get_language_percentage() helper and HardcoreConfirmView UI


