### PR TITLE
Treat >=97% as meeting hardcore threshold

### DIFF
--- a/cogs/general.py
+++ b/cogs/general.py
@@ -447,7 +447,11 @@ class General(commands.Cog):
             lang_name = {'es': 'Spanish', 'en': 'English'}.get(target_lang, target_lang)
             current_pct = hf.get_language_percentage(ctx.author.id, ctx.guild, target_lang) or 0
 
-            if current_pct < current_threshold:
+            # Cap at 97%: due to a bug, percentages above ~98.3% are unreachable,
+            # so anything >=97 counts as meeting the threshold.
+            effective_pct = 100 if current_pct >= 97 else current_pct
+
+            if effective_pct < current_threshold:
                 await utils.safe_send(
                     ctx,
                     f"You can't remove hardcore yet. You need **{current_threshold}%** in "


### PR DESCRIPTION

## Summary
- Language percentages cap around 98.3% due to an unidentified bug, which makes hardcore thresholds above that effectively unreachable and can permanently lock users in.
- When a user tries to remove hardcore, treat any current percentage >=97% as 100% for the gate check, so users who hit the practical ceiling can still remove the role.
- Failure message still shows the raw percentage, but it only fires below 97%, so the displayed number stays accurate.

## Risks
I haven't manually tested this bc I don't have a discord bot setup currently on my new Discord account, but it should work as expected tbh, I can test myself if necessary

## Test plan
- [ ] Set a lower hardcore threshold (e.g. 95%) and verify removal works once the user is at >=97%.
- [ ] Set a high threshold (e.g. 99%) and verify removal works once the user is at >=97%.
- [ ] Verify removal is still blocked when current percentage is below 97% and below the threshold.
- [ ] Verify the failure message still shows the actual current percentage.
