### PR TITLE
fix: resolve audit log author to Member before checking helper roles

### DIFF
--- a/cogs/logger.py
+++ b/cogs/logger.py
@@ -1908,7 +1908,8 @@ class Logger(commands.Cog):
                 guild.get_role(258819531193974784),   # server_helper
                 guild.get_role(243854949522472971),   # admin
             }
-            author_roles = set(author.roles)
+            author_member = guild.get_member(author.id)
+            author_roles = set(author_member.roles) if author_member else set()
 
             if helper_roles & author_roles:
                 if not elevated_staff_roles & author_roles:


### PR DESCRIPTION
## Summary

- `entry.user` from Discord audit logs returns a `discord.User` (not `discord.Member`) when the moderator is not currently in the member cache
- `discord.User` has no `.roles` attribute, so the role intersection check raised `AttributeError` and silently killed `check_timeouts()` before the helper channel notification could fire
- Fix resolves the author to a `guild.Member` via `guild.get_member()` first; falls back to an empty set if they are not cached, skipping the notification gracefully instead of crashing

## Root cause

```python
# before — crashes when author is a User (not cached as Member)
author_roles = set(author.roles)

# after — safe regardless of cache state
author_member = guild.get_member(author.id)
author_roles = set(author_member.roles) if author_member else set()
```

## Test plan

- [ ] Event helper times out a user → helper channel notification fires consistently
- [ ] Staff with elevated roles time out a user → no notification sent (unchanged behaviour)
- [ ] Confirm no `AttributeError` in logs when moderator is not in member cache