### PR TITLE
feat: show remaining users on voice leave, use display_name in voice log

### DIFF
--- a/cogs/logger.py
+++ b/cogs/logger.py
@@ -317,21 +317,24 @@ class Logger(commands.Cog):
         emb.set_footer(text=footer_text,
                        icon_url=member.display_avatar.replace(static_format="png").url)
         
-        if after.channel:
+        voice_channel = after.channel or before.channel
+        if voice_channel:
             users_in_voice = ""
             needed_two_fields = False
 
-            if isinstance(after.channel, discord.StageChannel):
+            if before.channel and not after.channel:
+                name_text = "Users remaining in channel"
+            elif isinstance(voice_channel, discord.StageChannel):
                 name_text = "Current stage channel speakers"
             else:
                 name_text = "Users currently in joined voice channel"
 
-            for user in after.channel.members:
+            for user in voice_channel.members:
                 if user.voice.suppress:  # a listener in a stage channel
                     pass
-                text_to_add = f"\n- [{str(user)}"
-                if user.nick:
-                    text_to_add += f" ({user.nick})"
+                text_to_add = f"\n- [{user.display_name}"
+                if user.display_name != user.name:
+                    text_to_add += f" ({user.name})"
                 text_to_add += f"](https://rai/participant-id-is-P{user.id})"
 
                 # Check to make sure the total length of the embed isn't going over 6000, cut off if so


### PR DESCRIPTION
## Summary

- **Voice leave channel state**: The member list field was only rendered when `after.channel` was set, meaning it was skipped entirely on leave events. Now uses `after.channel or before.channel` so leaves show the users still in the channel after departure, with the field labelled "Users remaining in channel".

- **display_name instead of str(user)**: Member entries previously showed `account_username (server_nick)`, which skipped the global name tier. Now uses `user.display_name` (resolves: server nick → global name → username) as the primary label, with `user.name` (account username) appended in parentheses only when it differs. No extra API calls — all resolved from the member cache.

## Before / After

**Before (join/switch only, account name + server nick):**
```
- [jaleel_19 (gengar)](https://rai/participant-id-is-P123)
```

**After (join/switch/leave, display name + account name):**
```
- [gengar (jaleel_19)](https://rai/participant-id-is-P123)
- [jaleel_19](https://rai/participant-id-is-P456)   ← no parens when display_name == name
```

## Test plan

- [ ] User leaves a voice channel → embed shows remaining members in "Users remaining in channel" field
- [ ] User joins a voice channel → embed shows current members as before
- [ ] User with global name set → displayed as `global_name (username)`
- [ ] User with server nick set → displayed as `server_nick (username)`
- [ ] User with only account username → displayed as `username` (no parentheses)